### PR TITLE
Support test names specified by comment

### DIFF
--- a/conformance-test-framework/src/main/java/org/jspecify/conformance/ConformanceTestReport.java
+++ b/conformance-test-framework/src/main/java/org/jspecify/conformance/ConformanceTestReport.java
@@ -130,7 +130,7 @@ public final class ConformanceTestReport {
 
   private static void writeFact(Formatter report, Fact fact, String status) {
     report.format(
-        "%s: %s:%d %s%n", status, fact.getFile(), fact.getLineNumber(), fact.getFactText());
+        "%s: %s:%s:%s%n", status, fact.getFile(), fact.getIdentifier(), fact.getFactText());
   }
 
   /** A builder for {@link ConformanceTestReport}s. */
@@ -191,6 +191,7 @@ public final class ConformanceTestReport {
 
     /** Builds the report. */
     ConformanceTestReport build() {
+      expectedFactReader.checkErrors();
       return new ConformanceTestReport(
           files.build(),
           index(expectedFacts.build(), Fact::getFile),

--- a/conformance-test-framework/src/main/java/org/jspecify/conformance/ExpectedFact.java
+++ b/conformance-test-framework/src/main/java/org/jspecify/conformance/ExpectedFact.java
@@ -151,14 +151,10 @@ public final class ExpectedFact extends Fact {
         lineNumber = i.nextIndex();
         Matcher matcher = EXPECTATION_COMMENT.matcher(line);
         if (matcher.matches()) {
-          String newTestName = matcher.group("testName");
-          if (newTestName != null) {
-            setTestName(newTestName);
-          } else {
-            String fact = matcher.group("fact");
-            if (fact != null) {
-              facts.put(lineNumber, fact.trim());
-            }
+          setTestName(matcher.group("testName"));
+          String fact = matcher.group("fact");
+          if (fact != null) {
+            facts.put(lineNumber, fact.trim());
           }
         } else {
           if (testName != null) {
@@ -175,20 +171,22 @@ public final class ExpectedFact extends Fact {
       return checkUniqueTestNames(expectedFacts.build());
     }
 
-    private void setTestName(String testName) {
-      testName = testName.trim();
-      check(facts.isEmpty(), "test name must come before assertions for a line");
-      check(
-          !ASCII_DIGIT.matchesAllOf(testName) && !testName.contains(":"),
-          "test name cannot be an integer or contain a colon: %s",
-          testName);
+    private void setTestName(@Nullable String testName) {
+      if (testName == null) {
+        return;
+      }
       check(this.testName == null, "test name already set");
-      this.testName = testName;
+      check(facts.isEmpty(), "test name must come before assertions for a line");
+      this.testName = testName.trim();
+      check(
+          !ASCII_DIGIT.matchesAllOf(this.testName) && !this.testName.contains(":"),
+          "test name cannot be an integer or contain a colon: %s",
+          this.testName);
     }
 
     private void check(boolean test, String format, Object... args) {
       if (!test) {
-        errors.add(String.format("  %s:%d: ", file, lineNumber) + String.format(format, args));
+        errors.add(String.format("  %s:%d: %s", file, lineNumber, String.format(format, args)));
       }
     }
 

--- a/conformance-test-framework/src/main/java/org/jspecify/conformance/ExpectedFact.java
+++ b/conformance-test-framework/src/main/java/org/jspecify/conformance/ExpectedFact.java
@@ -15,10 +15,15 @@
 package org.jspecify.conformance;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.collect.ImmutableSetMultimap.toImmutableSetMultimap;
 import static java.util.stream.Collectors.joining;
 
+import com.google.common.base.CharMatcher;
+import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.ListIterator;
@@ -26,6 +31,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import org.jspecify.annotations.Nullable;
 
 /**
  * An assertion that the tool behaves in a way consistent with a specific fact about a line in the
@@ -47,11 +53,14 @@ public final class ExpectedFact extends Fact {
           Pattern.compile("test:irrelevant-annotation:\\S+"),
           Pattern.compile("test:sink-type:[^:]+:.*"));
 
+  private final @Nullable String testName;
   private final String factText;
   private final long factLineNumber;
 
-  ExpectedFact(Path file, long lineNumber, String factText, long factLineNumber) {
+  ExpectedFact(
+      Path file, long lineNumber, @Nullable String testName, String factText, long factLineNumber) {
     super(file, lineNumber);
+    this.testName = testName;
     this.factText = factText;
     this.factLineNumber = factLineNumber;
   }
@@ -74,6 +83,11 @@ public final class ExpectedFact extends Fact {
   }
 
   @Override
+  public String getIdentifier() {
+    return testName == null ? super.getIdentifier() : testName;
+  }
+
+  @Override
   public boolean equals(Object o) {
     if (this == o) {
       return true;
@@ -84,19 +98,21 @@ public final class ExpectedFact extends Fact {
     ExpectedFact that = (ExpectedFact) o;
     return this.getFile().equals(that.getFile())
         && this.getLineNumber() == that.getLineNumber()
+        && Objects.equals(this.testName, that.testName)
         && this.factText.equals(that.factText)
         && this.factLineNumber == that.factLineNumber;
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(getFile(), getLineNumber(), factText);
+    return Objects.hash(getFile(), getLineNumber(), testName, factText);
   }
 
   @Override
   public String toString() {
     return toStringHelper(this)
         .add("file", getFile())
+        .add("testName", testName)
         .add("lineNumber", getLineNumber())
         .add("factText", factText)
         .add("factLineNumber", factLineNumber)
@@ -108,35 +124,93 @@ public final class ExpectedFact extends Fact {
 
     private static final Pattern EXPECTATION_COMMENT =
         Pattern.compile(
-            "\\s*// "
+            "\\s*// ("
+                + "(test:name:(?<testName>.*))"
+                + "|"
                 + ("(?<fact>"
                     + FACT_PATTERNS.stream().map(Pattern::pattern).collect(joining("|"))
                     + ")")
-                + "\\s*");
+                + ")\\s*");
+
+    private static final CharMatcher ASCII_DIGIT = CharMatcher.inRange('0', '9');
+
+    private final Map<Long, String> facts = new HashMap<>();
+    private final List<String> errors = new ArrayList<>();
+
+    private Path file;
+    private @Nullable String testName;
+    private long lineNumber;
 
     /** Reads expected facts from lines in a file. */
     ImmutableList<ExpectedFact> readExpectedFacts(Path file, List<String> lines) {
+      this.file = file;
       ImmutableList.Builder<ExpectedFact> expectedFacts = ImmutableList.builder();
-      Map<Long, String> facts = new HashMap<>();
       ListIterator<String> i = lines.listIterator();
       while (i.hasNext()) {
         String line = i.next();
-        long lineNumber = i.nextIndex();
+        lineNumber = i.nextIndex();
         Matcher matcher = EXPECTATION_COMMENT.matcher(line);
         if (matcher.matches()) {
-          String fact = matcher.group("fact");
-          if (fact != null) {
-            facts.put(lineNumber, fact.trim());
+          String newTestName = matcher.group("testName");
+          if (newTestName != null) {
+            setTestName(newTestName);
+          } else {
+            String fact = matcher.group("fact");
+            if (fact != null) {
+              facts.put(lineNumber, fact.trim());
+            }
           }
         } else {
+          if (testName != null) {
+            check(!facts.isEmpty(), "no expected facts for test named %s", testName);
+          }
           facts.forEach(
               (factLineNumber, factText) ->
-                  expectedFacts.add(new ExpectedFact(file, lineNumber, factText, factLineNumber)));
+                  expectedFacts.add(
+                      new ExpectedFact(file, lineNumber, testName, factText, factLineNumber)));
           facts.clear();
+          testName = null;
         }
       }
-      // TODO(netdpb): Report an error if facts is not empty.
-      return expectedFacts.build();
+      return checkUniqueTestNames(expectedFacts.build());
+    }
+
+    private void setTestName(String testName) {
+      testName = testName.trim();
+      check(facts.isEmpty(), "test name must come before assertions for a line");
+      check(
+          !ASCII_DIGIT.matchesAllOf(testName) && !testName.contains(":"),
+          "test name cannot be an integer or contain a colon: %s",
+          testName);
+      check(this.testName == null, "test name already set");
+      this.testName = testName;
+    }
+
+    private void check(boolean test, String format, Object... args) {
+      if (!test) {
+        errors.add(String.format("  %s:%d: ", file, lineNumber) + String.format(format, args));
+      }
+    }
+
+    private ImmutableList<ExpectedFact> checkUniqueTestNames(
+        ImmutableList<ExpectedFact> expectedFacts) {
+      expectedFacts.stream()
+          .filter(ef -> ef.testName != null)
+          .collect(toImmutableSetMultimap(ef -> ef.testName, ExpectedFact::getLineNumber))
+          .asMap()
+          .forEach(
+              (testName, lineNumbers) ->
+                  check(
+                      lineNumbers.size() == 1,
+                      "test name not unique: test '%s' appears on tests of lines %s",
+                      testName,
+                      lineNumbers));
+      return expectedFacts;
+    }
+
+    /** Throws if there were any errors encountered while reading expected facts. */
+    void checkErrors() {
+      checkArgument(errors.isEmpty(), "errors in test inputs:\n%s", Joiner.on('\n').join(errors));
     }
   }
 }

--- a/conformance-test-framework/src/main/java/org/jspecify/conformance/Fact.java
+++ b/conformance-test-framework/src/main/java/org/jspecify/conformance/Fact.java
@@ -39,4 +39,9 @@ abstract class Fact {
 
   /** The text form of the fact. */
   protected abstract String getFactText();
+
+  /** Returns an object that helps to identify this fact within a file. */
+  public String getIdentifier() {
+    return String.valueOf(getLineNumber());
+  }
 }

--- a/conformance-test-framework/src/test/java/org/jspecify/conformance/ExpectedFactTest.java
+++ b/conformance-test-framework/src/test/java/org/jspecify/conformance/ExpectedFactTest.java
@@ -17,6 +17,7 @@ package org.jspecify.conformance;
 
 import static com.google.common.truth.Truth.assertThat;
 import static java.util.Arrays.asList;
+import static org.junit.Assert.assertThrows;
 
 import com.google.common.collect.ImmutableList;
 import java.nio.file.Path;
@@ -37,7 +38,7 @@ public class ExpectedFactTest {
   }
 
   @Test
-  public void readExpectedFacts() {
+  public void readExpectedFacts_lineNumber() {
     assertThat(
             readExpectedFacts(
                 "// jspecify_nullness_mismatch ",
@@ -50,12 +51,105 @@ public class ExpectedFactTest {
                 "// test:irrelevant-annotation:@Nullable ",
                 "yet another line under test"))
         .containsExactly(
-            new ExpectedFact(FILE, 3, "jspecify_nullness_mismatch", 1),
-            new ExpectedFact(FILE, 3, "jspecify_nullness_mismatch plus_other_stuff", 2),
-            new ExpectedFact(FILE, 7, "test:cannot-convert:type1 to type2", 4),
-            new ExpectedFact(FILE, 7, "test:expression-type:type2:expr2", 5),
-            new ExpectedFact(FILE, 7, "test:sink-type:type1:expr1", 6),
-            new ExpectedFact(FILE, 9, "test:irrelevant-annotation:@Nullable", 8))
+            new ExpectedFact(FILE, 3, null, "jspecify_nullness_mismatch", 1),
+            new ExpectedFact(FILE, 3, null, "jspecify_nullness_mismatch plus_other_stuff", 2),
+            new ExpectedFact(FILE, 7, null, "test:cannot-convert:type1 to type2", 4),
+            new ExpectedFact(FILE, 7, null, "test:expression-type:type2:expr2", 5),
+            new ExpectedFact(FILE, 7, null, "test:sink-type:type1:expr1", 6),
+            new ExpectedFact(FILE, 9, null, "test:irrelevant-annotation:@Nullable", 8))
         .inOrder();
+    reader.checkErrors();
+  }
+
+  @Test
+  public void readExpectedFacts_name() {
+    assertThat(
+            readExpectedFacts(
+                "// test:name: test 1 ",
+                "// jspecify_nullness_mismatch ",
+                "// jspecify_nullness_mismatch plus_other_stuff ",
+                "line under test",
+                "// test:name: test 2 ",
+                "// test:cannot-convert:type1 to type2 ",
+                "// test:expression-type:type2:expr2 ",
+                "// test:sink-type:type1:expr1 ",
+                "another line under test",
+                "// test:name: test 3 ",
+                "// test:irrelevant-annotation:@Nullable ",
+                "yet another line under test"))
+        .containsExactly(
+            new ExpectedFact(FILE, 4, "test 1", "jspecify_nullness_mismatch", 2),
+            new ExpectedFact(FILE, 4, "test 1", "jspecify_nullness_mismatch plus_other_stuff", 3),
+            new ExpectedFact(FILE, 9, "test 2", "test:cannot-convert:type1 to type2", 6),
+            new ExpectedFact(FILE, 9, "test 2", "test:expression-type:type2:expr2", 7),
+            new ExpectedFact(FILE, 9, "test 2", "test:sink-type:type1:expr1", 8),
+            new ExpectedFact(FILE, 12, "test 3", "test:irrelevant-annotation:@Nullable", 11))
+        .inOrder();
+    reader.checkErrors();
+  }
+
+  @Test
+  public void readExpectedFacts_name_lineNumber_throws() {
+    ImmutableList<ExpectedFact> unused = readExpectedFacts("// test:name: 1234 ");
+    assertThat(assertThrows(IllegalArgumentException.class, () -> reader.checkErrors()))
+        .hasMessageThat()
+        .contains("test name cannot be an integer or contain a colon");
+  }
+
+  @Test
+  public void readExpectedFacts_name_colon_throws() {
+    ImmutableList<ExpectedFact> unused = readExpectedFacts("// test:name:has a : colon");
+    assertThat(assertThrows(IllegalArgumentException.class, () -> reader.checkErrors()))
+        .hasMessageThat()
+        .contains("test name cannot be an integer or contain a colon");
+  }
+
+  @Test
+  public void readExpectedFacts_name_notFirst_throws() {
+    ImmutableList<ExpectedFact> unused =
+        readExpectedFacts(
+            "// test:expression-type:type:expr", //
+            "// test:name:testName",
+            "line under test");
+    assertThat(assertThrows(IllegalArgumentException.class, () -> reader.checkErrors()))
+        .hasMessageThat()
+        .contains("test name must come before assertions for a line");
+  }
+
+  @Test
+  public void readExpectedFacts_name_noFact_throws() {
+    ImmutableList<ExpectedFact> unused =
+        readExpectedFacts(
+            "// test:name:testName", //
+            "line under test");
+    assertThat(assertThrows(IllegalArgumentException.class, () -> reader.checkErrors()))
+        .hasMessageThat()
+        .contains("no expected facts");
+  }
+
+  @Test
+  public void readExpectedFacts_name_second_name() {
+    ImmutableList<ExpectedFact> unused =
+        readExpectedFacts(
+            "// test:name:testName1", //
+            "// test:name:testName2");
+    assertThat(assertThrows(IllegalArgumentException.class, () -> reader.checkErrors()))
+        .hasMessageThat()
+        .contains("test name already set");
+  }
+
+  @Test
+  public void readExpectedFacts_name_notUnique() {
+    ImmutableList<ExpectedFact> unused =
+        readExpectedFacts(
+            "// test:name:testName", //
+            " // test:expression-type:type1:expr1",
+            "line 1 under test",
+            "// test:name:testName", //
+            " // test:expression-type:type2:expr2",
+            "line 2 under test");
+    assertThat(assertThrows(IllegalArgumentException.class, () -> reader.checkErrors()))
+        .hasMessageThat()
+        .contains("test name not unique: test 'testName' appears on tests of lines [3, 6]");
   }
 }

--- a/conformance-test-framework/src/test/java/org/jspecify/conformance/ExpectedFactTest.java
+++ b/conformance-test-framework/src/test/java/org/jspecify/conformance/ExpectedFactTest.java
@@ -38,7 +38,7 @@ public class ExpectedFactTest {
   }
 
   @Test
-  public void readExpectedFacts_lineNumber() {
+  public void readExpectedFacts() {
     assertThat(
             readExpectedFacts(
                 "// jspecify_nullness_mismatch ",
@@ -89,7 +89,7 @@ public class ExpectedFactTest {
   }
 
   @Test
-  public void readExpectedFacts_name_lineNumber_throws() {
+  public void readExpectedFacts_name_allDigits_throws() {
     ImmutableList<ExpectedFact> unused = readExpectedFacts("// test:name: 1234 ");
     assertThat(assertThrows(IllegalArgumentException.class, () -> reader.checkErrors()))
         .hasMessageThat()
@@ -142,10 +142,10 @@ public class ExpectedFactTest {
   public void readExpectedFacts_name_notUnique() {
     ImmutableList<ExpectedFact> unused =
         readExpectedFacts(
-            "// test:name:testName", //
+            "// test:name:testName",
             " // test:expression-type:type1:expr1",
             "line 1 under test",
-            "// test:name:testName", //
+            "// test:name:testName",
             " // test:expression-type:type2:expr2",
             "line 2 under test");
     assertThat(assertThrows(IllegalArgumentException.class, () -> reader.checkErrors()))

--- a/tests/ConformanceTest-report.txt
+++ b/tests/ConformanceTest-report.txt
@@ -1,20 +1,20 @@
 # 12 pass; 7 fail; 19 total; 63.2% score
-PASS: Basic.java:28 test:expression-type:Object?:nullable
-PASS: Basic.java:28 test:sink-type:Object!:return
-PASS: Basic.java:28 test:cannot-convert:Object? to Object!
-PASS: Basic.java:34 test:expression-type:Object!:nonNull
-PASS: Basic.java:34 test:sink-type:Object?:return
-PASS: Basic.java:41 test:sink-type:Object?:nullableObject
-PASS: Basic.java:43 test:sink-type:String!:testSinkType#nonNullString
-FAIL: Basic.java:49 test:expression-type:List!<capture of ? extends String?>:nullableStrings
+PASS: Basic.java:28:test:expression-type:Object?:nullable
+PASS: Basic.java:28:test:sink-type:Object!:return
+PASS: Basic.java:28:test:cannot-convert:Object? to Object!
+PASS: Basic.java:34:test:expression-type:Object!:nonNull
+PASS: Basic.java:34:test:sink-type:Object?:return
+PASS: Basic.java:41:test:sink-type:Object?:nullableObject
+PASS: Basic.java:43:test:sink-type:String!:testSinkType#nonNullString
+FAIL: Basic.java:49:test:expression-type:List!<capture of ? extends String?>:nullableStrings
 PASS: Basic.java: no unexpected facts
-PASS: Irrelevant.java:28 test:irrelevant-annotation:Nullable
-PASS: Irrelevant.java:34 test:irrelevant-annotation:Nullable
-FAIL: Irrelevant.java:38 test:irrelevant-annotation:NonNull
-FAIL: Irrelevant.java:43 test:irrelevant-annotation:NonNull
-FAIL: Irrelevant.java:43 test:irrelevant-annotation:Nullable
-FAIL: Irrelevant.java:47 test:irrelevant-annotation:NullMarked
-FAIL: Irrelevant.java:49 test:irrelevant-annotation:NullUnmarked
+PASS: Irrelevant.java:28:test:irrelevant-annotation:Nullable
+PASS: Irrelevant.java:34:test:irrelevant-annotation:Nullable
+FAIL: Irrelevant.java:38:test:irrelevant-annotation:NonNull
+FAIL: Irrelevant.java:43:test:irrelevant-annotation:NonNull
+FAIL: Irrelevant.java:43:test:irrelevant-annotation:Nullable
+FAIL: Irrelevant.java:47:test:irrelevant-annotation:NullMarked
+FAIL: Irrelevant.java:49:test:irrelevant-annotation:NullUnmarked
 FAIL: Irrelevant.java: no unexpected facts
-PASS: UsesDep.java:24 test:cannot-convert:null? to Dep*
+PASS: UsesDep.java:24:test:cannot-convert:null? to Dep*
 PASS: UsesDep.java: no unexpected facts

--- a/tests/ConformanceTestOnSamples-report.txt
+++ b/tests/ConformanceTestOnSamples-report.txt
@@ -6,222 +6,222 @@ FAIL: AnnotatedTypeParameter.java: no unexpected facts
 FAIL: AnnotatedTypeParameterUnspec.java: no unexpected facts
 FAIL: AnnotatedWildcard.java: no unexpected facts
 FAIL: AnnotatedWildcardUnspec.java: no unexpected facts
-FAIL: ArraySameType.java:35 jspecify_nullness_mismatch
-FAIL: ArraySameType.java:49 jspecify_nullness_mismatch
+FAIL: ArraySameType.java:35:jspecify_nullness_mismatch
+FAIL: ArraySameType.java:49:jspecify_nullness_mismatch
 FAIL: ArraySameType.java: no unexpected facts
-FAIL: ArraySubtype.java:44 jspecify_nullness_mismatch
+FAIL: ArraySubtype.java:44:jspecify_nullness_mismatch
 FAIL: ArraySubtype.java: no unexpected facts
 PASS: AssignmentAsExpression.java: no unexpected facts
-PASS: AugmentedInferenceAgreesWithBaseInference.java:35 jspecify_nullness_mismatch
+PASS: AugmentedInferenceAgreesWithBaseInference.java:35:jspecify_nullness_mismatch
 PASS: AugmentedInferenceAgreesWithBaseInference.java: no unexpected facts
-PASS: BoundedTypeVariableReturn.java:27 jspecify_nullness_mismatch
-PASS: BoundedTypeVariableReturn.java:32 jspecify_nullness_mismatch
+PASS: BoundedTypeVariableReturn.java:27:jspecify_nullness_mismatch
+PASS: BoundedTypeVariableReturn.java:32:jspecify_nullness_mismatch
 PASS: BoundedTypeVariableReturn.java: no unexpected facts
-FAIL: CaptureAsInferredTypeArgument.java:51 jspecify_nullness_mismatch
-FAIL: CaptureAsInferredTypeArgument.java:53 jspecify_nullness_mismatch
-FAIL: CaptureAsInferredTypeArgument.java:61 jspecify_nullness_mismatch
-FAIL: CaptureAsInferredTypeArgument.java:63 jspecify_nullness_mismatch
+FAIL: CaptureAsInferredTypeArgument.java:51:jspecify_nullness_mismatch
+FAIL: CaptureAsInferredTypeArgument.java:53:jspecify_nullness_mismatch
+FAIL: CaptureAsInferredTypeArgument.java:61:jspecify_nullness_mismatch
+FAIL: CaptureAsInferredTypeArgument.java:63:jspecify_nullness_mismatch
 FAIL: CaptureAsInferredTypeArgument.java: no unexpected facts
 PASS: CaptureConversionForSubtyping.java: no unexpected facts
-FAIL: CaptureConvertedToObject.java:71 jspecify_nullness_mismatch
+FAIL: CaptureConvertedToObject.java:71:jspecify_nullness_mismatch
 FAIL: CaptureConvertedToObject.java: no unexpected facts
 FAIL: CaptureConvertedToObjectUnionNull.java: no unexpected facts
 FAIL: CaptureConvertedToObjectUnspec.java: no unexpected facts
-FAIL: CaptureConvertedToOther.java:71 jspecify_nullness_mismatch
+FAIL: CaptureConvertedToOther.java:71:jspecify_nullness_mismatch
 FAIL: CaptureConvertedToOther.java: no unexpected facts
 FAIL: CaptureConvertedToOtherUnionNull.java: no unexpected facts
 FAIL: CaptureConvertedToOtherUnspec.java: no unexpected facts
-FAIL: CaptureConvertedUnionNullToObject.java:24 jspecify_nullness_mismatch
-FAIL: CaptureConvertedUnionNullToObject.java:29 jspecify_nullness_mismatch
-FAIL: CaptureConvertedUnionNullToObject.java:34 jspecify_nullness_mismatch
-FAIL: CaptureConvertedUnionNullToObject.java:39 jspecify_nullness_mismatch
-FAIL: CaptureConvertedUnionNullToObject.java:44 jspecify_nullness_mismatch
-FAIL: CaptureConvertedUnionNullToObject.java:49 jspecify_nullness_mismatch
-FAIL: CaptureConvertedUnionNullToObject.java:54 jspecify_nullness_mismatch
-FAIL: CaptureConvertedUnionNullToObject.java:59 jspecify_nullness_mismatch
-FAIL: CaptureConvertedUnionNullToObject.java:64 jspecify_nullness_mismatch
-FAIL: CaptureConvertedUnionNullToObject.java:69 jspecify_nullness_mismatch
-FAIL: CaptureConvertedUnionNullToObject.java:74 jspecify_nullness_mismatch
-FAIL: CaptureConvertedUnionNullToObject.java:79 jspecify_nullness_mismatch
+FAIL: CaptureConvertedUnionNullToObject.java:24:jspecify_nullness_mismatch
+FAIL: CaptureConvertedUnionNullToObject.java:29:jspecify_nullness_mismatch
+FAIL: CaptureConvertedUnionNullToObject.java:34:jspecify_nullness_mismatch
+FAIL: CaptureConvertedUnionNullToObject.java:39:jspecify_nullness_mismatch
+FAIL: CaptureConvertedUnionNullToObject.java:44:jspecify_nullness_mismatch
+FAIL: CaptureConvertedUnionNullToObject.java:49:jspecify_nullness_mismatch
+FAIL: CaptureConvertedUnionNullToObject.java:54:jspecify_nullness_mismatch
+FAIL: CaptureConvertedUnionNullToObject.java:59:jspecify_nullness_mismatch
+FAIL: CaptureConvertedUnionNullToObject.java:64:jspecify_nullness_mismatch
+FAIL: CaptureConvertedUnionNullToObject.java:69:jspecify_nullness_mismatch
+FAIL: CaptureConvertedUnionNullToObject.java:74:jspecify_nullness_mismatch
+FAIL: CaptureConvertedUnionNullToObject.java:79:jspecify_nullness_mismatch
 FAIL: CaptureConvertedUnionNullToObject.java: no unexpected facts
 FAIL: CaptureConvertedUnionNullToObjectUnionNull.java: no unexpected facts
 FAIL: CaptureConvertedUnionNullToObjectUnspec.java: no unexpected facts
-FAIL: CaptureConvertedUnionNullToOther.java:24 jspecify_nullness_mismatch
-FAIL: CaptureConvertedUnionNullToOther.java:29 jspecify_nullness_mismatch
-FAIL: CaptureConvertedUnionNullToOther.java:34 jspecify_nullness_mismatch
-FAIL: CaptureConvertedUnionNullToOther.java:39 jspecify_nullness_mismatch
-FAIL: CaptureConvertedUnionNullToOther.java:44 jspecify_nullness_mismatch
-FAIL: CaptureConvertedUnionNullToOther.java:49 jspecify_nullness_mismatch
-FAIL: CaptureConvertedUnionNullToOther.java:54 jspecify_nullness_mismatch
-FAIL: CaptureConvertedUnionNullToOther.java:59 jspecify_nullness_mismatch
-FAIL: CaptureConvertedUnionNullToOther.java:64 jspecify_nullness_mismatch
-FAIL: CaptureConvertedUnionNullToOther.java:69 jspecify_nullness_mismatch
-FAIL: CaptureConvertedUnionNullToOther.java:74 jspecify_nullness_mismatch
-FAIL: CaptureConvertedUnionNullToOther.java:79 jspecify_nullness_mismatch
+FAIL: CaptureConvertedUnionNullToOther.java:24:jspecify_nullness_mismatch
+FAIL: CaptureConvertedUnionNullToOther.java:29:jspecify_nullness_mismatch
+FAIL: CaptureConvertedUnionNullToOther.java:34:jspecify_nullness_mismatch
+FAIL: CaptureConvertedUnionNullToOther.java:39:jspecify_nullness_mismatch
+FAIL: CaptureConvertedUnionNullToOther.java:44:jspecify_nullness_mismatch
+FAIL: CaptureConvertedUnionNullToOther.java:49:jspecify_nullness_mismatch
+FAIL: CaptureConvertedUnionNullToOther.java:54:jspecify_nullness_mismatch
+FAIL: CaptureConvertedUnionNullToOther.java:59:jspecify_nullness_mismatch
+FAIL: CaptureConvertedUnionNullToOther.java:64:jspecify_nullness_mismatch
+FAIL: CaptureConvertedUnionNullToOther.java:69:jspecify_nullness_mismatch
+FAIL: CaptureConvertedUnionNullToOther.java:74:jspecify_nullness_mismatch
+FAIL: CaptureConvertedUnionNullToOther.java:79:jspecify_nullness_mismatch
 FAIL: CaptureConvertedUnionNullToOther.java: no unexpected facts
 FAIL: CaptureConvertedUnionNullToOtherUnionNull.java: no unexpected facts
 FAIL: CaptureConvertedUnionNullToOtherUnspec.java: no unexpected facts
-FAIL: CaptureConvertedUnspecToObject.java:79 jspecify_nullness_mismatch
+FAIL: CaptureConvertedUnspecToObject.java:79:jspecify_nullness_mismatch
 FAIL: CaptureConvertedUnspecToObject.java: no unexpected facts
 FAIL: CaptureConvertedUnspecToObjectUnionNull.java: no unexpected facts
 FAIL: CaptureConvertedUnspecToObjectUnspec.java: no unexpected facts
-FAIL: CaptureConvertedUnspecToOther.java:79 jspecify_nullness_mismatch
+FAIL: CaptureConvertedUnspecToOther.java:79:jspecify_nullness_mismatch
 FAIL: CaptureConvertedUnspecToOther.java: no unexpected facts
 FAIL: CaptureConvertedUnspecToOtherUnionNull.java: no unexpected facts
 FAIL: CaptureConvertedUnspecToOtherUnspec.java: no unexpected facts
 PASS: CastOfCaptureOfNotNullMarkedUnboundedWildcardForObjectBoundedTypeParameter.java: no unexpected facts
 FAIL: CastOfCaptureOfUnboundedWildcardForNotNullMarkedObjectBoundedTypeParameter.java: no unexpected facts
 PASS: CastOfCaptureOfUnboundedWildcardForObjectBoundedTypeParameter.java: no unexpected facts
-FAIL: CastToPrimitive.java:33 jspecify_nullness_mismatch
+FAIL: CastToPrimitive.java:33:jspecify_nullness_mismatch
 FAIL: CastToPrimitive.java: no unexpected facts
-PASS: CastWildcardToTypeVariable.java:23 jspecify_nullness_mismatch
+PASS: CastWildcardToTypeVariable.java:23:jspecify_nullness_mismatch
 PASS: CastWildcardToTypeVariable.java: no unexpected facts
 PASS: Catch.java: no unexpected facts
 PASS: ClassLiteral.java: no unexpected facts
-FAIL: ClassToObject.java:33 jspecify_nullness_mismatch
+FAIL: ClassToObject.java:33:jspecify_nullness_mismatch
 FAIL: ClassToObject.java: no unexpected facts
-FAIL: ClassToSelf.java:33 jspecify_nullness_mismatch
+FAIL: ClassToSelf.java:33:jspecify_nullness_mismatch
 FAIL: ClassToSelf.java: no unexpected facts
-FAIL: ComplexParametric.java:58 jspecify_nullness_mismatch
-FAIL: ComplexParametric.java:72 jspecify_nullness_mismatch
-FAIL: ComplexParametric.java:76 jspecify_nullness_mismatch
-FAIL: ComplexParametric.java:92 jspecify_nullness_mismatch
-FAIL: ComplexParametric.java:106 jspecify_nullness_mismatch
-FAIL: ComplexParametric.java:110 jspecify_nullness_mismatch
-FAIL: ComplexParametric.java:126 jspecify_nullness_mismatch
-FAIL: ComplexParametric.java:140 jspecify_nullness_mismatch
-FAIL: ComplexParametric.java:144 jspecify_nullness_mismatch
-FAIL: ComplexParametric.java:160 jspecify_nullness_mismatch
-FAIL: ComplexParametric.java:174 jspecify_nullness_mismatch
-FAIL: ComplexParametric.java:178 jspecify_nullness_mismatch
-FAIL: ComplexParametric.java:204 jspecify_nullness_mismatch
-FAIL: ComplexParametric.java:218 jspecify_nullness_mismatch
-FAIL: ComplexParametric.java:222 jspecify_nullness_mismatch
-FAIL: ComplexParametric.java:238 jspecify_nullness_mismatch
-FAIL: ComplexParametric.java:240 jspecify_nullness_mismatch
-FAIL: ComplexParametric.java:245 jspecify_nullness_mismatch
-FAIL: ComplexParametric.java:248 jspecify_nullness_mismatch
-FAIL: ComplexParametric.java:259 jspecify_nullness_mismatch
-FAIL: ComplexParametric.java:263 jspecify_nullness_mismatch
+FAIL: ComplexParametric.java:58:jspecify_nullness_mismatch
+FAIL: ComplexParametric.java:72:jspecify_nullness_mismatch
+FAIL: ComplexParametric.java:76:jspecify_nullness_mismatch
+FAIL: ComplexParametric.java:92:jspecify_nullness_mismatch
+FAIL: ComplexParametric.java:106:jspecify_nullness_mismatch
+FAIL: ComplexParametric.java:110:jspecify_nullness_mismatch
+FAIL: ComplexParametric.java:126:jspecify_nullness_mismatch
+FAIL: ComplexParametric.java:140:jspecify_nullness_mismatch
+FAIL: ComplexParametric.java:144:jspecify_nullness_mismatch
+FAIL: ComplexParametric.java:160:jspecify_nullness_mismatch
+FAIL: ComplexParametric.java:174:jspecify_nullness_mismatch
+FAIL: ComplexParametric.java:178:jspecify_nullness_mismatch
+FAIL: ComplexParametric.java:204:jspecify_nullness_mismatch
+FAIL: ComplexParametric.java:218:jspecify_nullness_mismatch
+FAIL: ComplexParametric.java:222:jspecify_nullness_mismatch
+FAIL: ComplexParametric.java:238:jspecify_nullness_mismatch
+FAIL: ComplexParametric.java:240:jspecify_nullness_mismatch
+FAIL: ComplexParametric.java:245:jspecify_nullness_mismatch
+FAIL: ComplexParametric.java:248:jspecify_nullness_mismatch
+FAIL: ComplexParametric.java:259:jspecify_nullness_mismatch
+FAIL: ComplexParametric.java:263:jspecify_nullness_mismatch
 FAIL: ComplexParametric.java: no unexpected facts
 FAIL: ConcatResult.java: no unexpected facts
 FAIL: ConflictingAnnotations.java: no unexpected facts
 PASS: Constants.java: no unexpected facts
-FAIL: ContainmentExtends.java:29 jspecify_nullness_mismatch
+FAIL: ContainmentExtends.java:29:jspecify_nullness_mismatch
 FAIL: ContainmentExtends.java: no unexpected facts
 PASS: ContainmentExtendsBounded.java: no unexpected facts
-FAIL: ContainmentSuper.java:38 jspecify_nullness_mismatch
+FAIL: ContainmentSuper.java:38:jspecify_nullness_mismatch
 FAIL: ContainmentSuper.java: no unexpected facts
-FAIL: ContainmentSuperVsExtends.java:24 jspecify_nullness_mismatch
+FAIL: ContainmentSuperVsExtends.java:24:jspecify_nullness_mismatch
 FAIL: ContainmentSuperVsExtends.java: no unexpected facts
-FAIL: ContainmentSuperVsExtendsSameType.java:23 jspecify_nullness_mismatch
+FAIL: ContainmentSuperVsExtendsSameType.java:23:jspecify_nullness_mismatch
 PASS: ContainmentSuperVsExtendsSameType.java: no unexpected facts
-PASS: ContravariantReturns.java:30 jspecify_nullness_mismatch
-PASS: ContravariantReturns.java:34 jspecify_nullness_mismatch
-PASS: ContravariantReturns.java:38 jspecify_nullness_mismatch
+PASS: ContravariantReturns.java:30:jspecify_nullness_mismatch
+PASS: ContravariantReturns.java:34:jspecify_nullness_mismatch
+PASS: ContravariantReturns.java:38:jspecify_nullness_mismatch
 PASS: ContravariantReturns.java: no unexpected facts
 PASS: CovariantReturns.java: no unexpected facts
-FAIL: DereferenceClass.java:33 jspecify_nullness_mismatch
+FAIL: DereferenceClass.java:33:jspecify_nullness_mismatch
 FAIL: DereferenceClass.java: no unexpected facts
-FAIL: DereferenceIntersection.java:82 jspecify_nullness_mismatch
+FAIL: DereferenceIntersection.java:82:jspecify_nullness_mismatch
 FAIL: DereferenceIntersection.java: no unexpected facts
-PASS: DereferenceTernary.java:23 jspecify_nullness_mismatch
+PASS: DereferenceTernary.java:23:jspecify_nullness_mismatch
 PASS: DereferenceTernary.java: no unexpected facts
-FAIL: DereferenceTypeVariable.java:61 jspecify_nullness_mismatch
-FAIL: DereferenceTypeVariable.java:83 jspecify_nullness_mismatch
-FAIL: DereferenceTypeVariable.java:107 jspecify_nullness_mismatch
-FAIL: DereferenceTypeVariable.java:113 jspecify_nullness_mismatch
-FAIL: DereferenceTypeVariable.java:119 jspecify_nullness_mismatch
-FAIL: DereferenceTypeVariable.java:125 jspecify_nullness_mismatch
-FAIL: DereferenceTypeVariable.java:131 jspecify_nullness_mismatch
+FAIL: DereferenceTypeVariable.java:61:jspecify_nullness_mismatch
+FAIL: DereferenceTypeVariable.java:83:jspecify_nullness_mismatch
+FAIL: DereferenceTypeVariable.java:107:jspecify_nullness_mismatch
+FAIL: DereferenceTypeVariable.java:113:jspecify_nullness_mismatch
+FAIL: DereferenceTypeVariable.java:119:jspecify_nullness_mismatch
+FAIL: DereferenceTypeVariable.java:125:jspecify_nullness_mismatch
+FAIL: DereferenceTypeVariable.java:131:jspecify_nullness_mismatch
 FAIL: DereferenceTypeVariable.java: no unexpected facts
 FAIL: EnumAnnotations.java: no unexpected facts
-FAIL: ExtendsSameType.java:39 jspecify_nullness_mismatch
-FAIL: ExtendsSameType.java:53 jspecify_nullness_mismatch
+FAIL: ExtendsSameType.java:39:jspecify_nullness_mismatch
+FAIL: ExtendsSameType.java:53:jspecify_nullness_mismatch
 FAIL: ExtendsSameType.java: no unexpected facts
-FAIL: ExtendsTypeVariableImplementedForNullableTypeArgument.java:30 jspecify_nullness_mismatch
-FAIL: ExtendsTypeVariableImplementedForNullableTypeArgument.java:35 jspecify_nullness_mismatch
+FAIL: ExtendsTypeVariableImplementedForNullableTypeArgument.java:30:jspecify_nullness_mismatch
+FAIL: ExtendsTypeVariableImplementedForNullableTypeArgument.java:35:jspecify_nullness_mismatch
 FAIL: ExtendsTypeVariableImplementedForNullableTypeArgument.java: no unexpected facts
-FAIL: ExtendsVsExtendsNullable.java:42 jspecify_nullness_mismatch
+FAIL: ExtendsVsExtendsNullable.java:42:jspecify_nullness_mismatch
 FAIL: ExtendsVsExtendsNullable.java: no unexpected facts
-FAIL: IfCondition.java:45 jspecify_nullness_mismatch
+FAIL: IfCondition.java:45:jspecify_nullness_mismatch
 FAIL: IfCondition.java: no unexpected facts
 PASS: InferenceChoosesNullableTypeVariable.java: no unexpected facts
-FAIL: InstanceOfCheck.java:44 jspecify_nullness_mismatch
+FAIL: InstanceOfCheck.java:44:jspecify_nullness_mismatch
 FAIL: InstanceOfCheck.java: no unexpected facts
-FAIL: IntersectionSupertype.java:74 jspecify_nullness_mismatch
-FAIL: IntersectionSupertype.java:76 jspecify_nullness_mismatch
-FAIL: IntersectionSupertype.java:78 jspecify_nullness_mismatch
-FAIL: IntersectionSupertype.java:80 jspecify_nullness_mismatch
-FAIL: IntersectionSupertype.java:86 jspecify_nullness_mismatch
+FAIL: IntersectionSupertype.java:74:jspecify_nullness_mismatch
+FAIL: IntersectionSupertype.java:76:jspecify_nullness_mismatch
+FAIL: IntersectionSupertype.java:78:jspecify_nullness_mismatch
+FAIL: IntersectionSupertype.java:80:jspecify_nullness_mismatch
+FAIL: IntersectionSupertype.java:86:jspecify_nullness_mismatch
 FAIL: IntersectionSupertype.java: no unexpected facts
-FAIL: LocalVariable.java:44 jspecify_nullness_mismatch
+FAIL: LocalVariable.java:44:jspecify_nullness_mismatch
 FAIL: LocalVariable.java: no unexpected facts
-FAIL: MultiBoundTypeVariableToObject.java:59 jspecify_nullness_mismatch
+FAIL: MultiBoundTypeVariableToObject.java:59:jspecify_nullness_mismatch
 FAIL: MultiBoundTypeVariableToObject.java: no unexpected facts
 FAIL: MultiBoundTypeVariableToObjectUnionNull.java: no unexpected facts
 FAIL: MultiBoundTypeVariableToObjectUnspec.java: no unexpected facts
-FAIL: MultiBoundTypeVariableToOther.java:59 jspecify_nullness_mismatch
+FAIL: MultiBoundTypeVariableToOther.java:59:jspecify_nullness_mismatch
 FAIL: MultiBoundTypeVariableToOther.java: no unexpected facts
 FAIL: MultiBoundTypeVariableToOtherUnionNull.java: no unexpected facts
 FAIL: MultiBoundTypeVariableToOtherUnspec.java: no unexpected facts
 FAIL: MultiBoundTypeVariableToSelf.java: no unexpected facts
 FAIL: MultiBoundTypeVariableToSelfUnionNull.java: no unexpected facts
 FAIL: MultiBoundTypeVariableToSelfUnspec.java: no unexpected facts
-FAIL: MultiBoundTypeVariableUnionNullToObject.java:24 jspecify_nullness_mismatch
-FAIL: MultiBoundTypeVariableUnionNullToObject.java:29 jspecify_nullness_mismatch
-FAIL: MultiBoundTypeVariableUnionNullToObject.java:34 jspecify_nullness_mismatch
-FAIL: MultiBoundTypeVariableUnionNullToObject.java:39 jspecify_nullness_mismatch
-FAIL: MultiBoundTypeVariableUnionNullToObject.java:44 jspecify_nullness_mismatch
-FAIL: MultiBoundTypeVariableUnionNullToObject.java:49 jspecify_nullness_mismatch
-FAIL: MultiBoundTypeVariableUnionNullToObject.java:54 jspecify_nullness_mismatch
-FAIL: MultiBoundTypeVariableUnionNullToObject.java:59 jspecify_nullness_mismatch
-FAIL: MultiBoundTypeVariableUnionNullToObject.java:64 jspecify_nullness_mismatch
+FAIL: MultiBoundTypeVariableUnionNullToObject.java:24:jspecify_nullness_mismatch
+FAIL: MultiBoundTypeVariableUnionNullToObject.java:29:jspecify_nullness_mismatch
+FAIL: MultiBoundTypeVariableUnionNullToObject.java:34:jspecify_nullness_mismatch
+FAIL: MultiBoundTypeVariableUnionNullToObject.java:39:jspecify_nullness_mismatch
+FAIL: MultiBoundTypeVariableUnionNullToObject.java:44:jspecify_nullness_mismatch
+FAIL: MultiBoundTypeVariableUnionNullToObject.java:49:jspecify_nullness_mismatch
+FAIL: MultiBoundTypeVariableUnionNullToObject.java:54:jspecify_nullness_mismatch
+FAIL: MultiBoundTypeVariableUnionNullToObject.java:59:jspecify_nullness_mismatch
+FAIL: MultiBoundTypeVariableUnionNullToObject.java:64:jspecify_nullness_mismatch
 FAIL: MultiBoundTypeVariableUnionNullToObject.java: no unexpected facts
 FAIL: MultiBoundTypeVariableUnionNullToObjectUnionNull.java: no unexpected facts
 FAIL: MultiBoundTypeVariableUnionNullToObjectUnspec.java: no unexpected facts
-FAIL: MultiBoundTypeVariableUnionNullToOther.java:24 jspecify_nullness_mismatch
-FAIL: MultiBoundTypeVariableUnionNullToOther.java:29 jspecify_nullness_mismatch
-FAIL: MultiBoundTypeVariableUnionNullToOther.java:34 jspecify_nullness_mismatch
-FAIL: MultiBoundTypeVariableUnionNullToOther.java:39 jspecify_nullness_mismatch
-FAIL: MultiBoundTypeVariableUnionNullToOther.java:44 jspecify_nullness_mismatch
-FAIL: MultiBoundTypeVariableUnionNullToOther.java:49 jspecify_nullness_mismatch
-FAIL: MultiBoundTypeVariableUnionNullToOther.java:54 jspecify_nullness_mismatch
-FAIL: MultiBoundTypeVariableUnionNullToOther.java:59 jspecify_nullness_mismatch
-FAIL: MultiBoundTypeVariableUnionNullToOther.java:64 jspecify_nullness_mismatch
+FAIL: MultiBoundTypeVariableUnionNullToOther.java:24:jspecify_nullness_mismatch
+FAIL: MultiBoundTypeVariableUnionNullToOther.java:29:jspecify_nullness_mismatch
+FAIL: MultiBoundTypeVariableUnionNullToOther.java:34:jspecify_nullness_mismatch
+FAIL: MultiBoundTypeVariableUnionNullToOther.java:39:jspecify_nullness_mismatch
+FAIL: MultiBoundTypeVariableUnionNullToOther.java:44:jspecify_nullness_mismatch
+FAIL: MultiBoundTypeVariableUnionNullToOther.java:49:jspecify_nullness_mismatch
+FAIL: MultiBoundTypeVariableUnionNullToOther.java:54:jspecify_nullness_mismatch
+FAIL: MultiBoundTypeVariableUnionNullToOther.java:59:jspecify_nullness_mismatch
+FAIL: MultiBoundTypeVariableUnionNullToOther.java:64:jspecify_nullness_mismatch
 FAIL: MultiBoundTypeVariableUnionNullToOther.java: no unexpected facts
 FAIL: MultiBoundTypeVariableUnionNullToOtherUnionNull.java: no unexpected facts
 FAIL: MultiBoundTypeVariableUnionNullToOtherUnspec.java: no unexpected facts
-FAIL: MultiBoundTypeVariableUnionNullToSelf.java:24 jspecify_nullness_mismatch
-FAIL: MultiBoundTypeVariableUnionNullToSelf.java:29 jspecify_nullness_mismatch
-FAIL: MultiBoundTypeVariableUnionNullToSelf.java:34 jspecify_nullness_mismatch
-FAIL: MultiBoundTypeVariableUnionNullToSelf.java:39 jspecify_nullness_mismatch
-FAIL: MultiBoundTypeVariableUnionNullToSelf.java:44 jspecify_nullness_mismatch
-FAIL: MultiBoundTypeVariableUnionNullToSelf.java:49 jspecify_nullness_mismatch
-FAIL: MultiBoundTypeVariableUnionNullToSelf.java:54 jspecify_nullness_mismatch
-FAIL: MultiBoundTypeVariableUnionNullToSelf.java:59 jspecify_nullness_mismatch
-FAIL: MultiBoundTypeVariableUnionNullToSelf.java:64 jspecify_nullness_mismatch
+FAIL: MultiBoundTypeVariableUnionNullToSelf.java:24:jspecify_nullness_mismatch
+FAIL: MultiBoundTypeVariableUnionNullToSelf.java:29:jspecify_nullness_mismatch
+FAIL: MultiBoundTypeVariableUnionNullToSelf.java:34:jspecify_nullness_mismatch
+FAIL: MultiBoundTypeVariableUnionNullToSelf.java:39:jspecify_nullness_mismatch
+FAIL: MultiBoundTypeVariableUnionNullToSelf.java:44:jspecify_nullness_mismatch
+FAIL: MultiBoundTypeVariableUnionNullToSelf.java:49:jspecify_nullness_mismatch
+FAIL: MultiBoundTypeVariableUnionNullToSelf.java:54:jspecify_nullness_mismatch
+FAIL: MultiBoundTypeVariableUnionNullToSelf.java:59:jspecify_nullness_mismatch
+FAIL: MultiBoundTypeVariableUnionNullToSelf.java:64:jspecify_nullness_mismatch
 FAIL: MultiBoundTypeVariableUnionNullToSelf.java: no unexpected facts
 FAIL: MultiBoundTypeVariableUnionNullToSelfUnionNull.java: no unexpected facts
 FAIL: MultiBoundTypeVariableUnionNullToSelfUnspec.java: no unexpected facts
-FAIL: MultiBoundTypeVariableUnspecToObject.java:65 jspecify_nullness_mismatch
+FAIL: MultiBoundTypeVariableUnspecToObject.java:65:jspecify_nullness_mismatch
 FAIL: MultiBoundTypeVariableUnspecToObject.java: no unexpected facts
 FAIL: MultiBoundTypeVariableUnspecToObjectUnionNull.java: no unexpected facts
 FAIL: MultiBoundTypeVariableUnspecToObjectUnspec.java: no unexpected facts
-FAIL: MultiBoundTypeVariableUnspecToOther.java:65 jspecify_nullness_mismatch
+FAIL: MultiBoundTypeVariableUnspecToOther.java:65:jspecify_nullness_mismatch
 FAIL: MultiBoundTypeVariableUnspecToOther.java: no unexpected facts
 FAIL: MultiBoundTypeVariableUnspecToOtherUnionNull.java: no unexpected facts
 FAIL: MultiBoundTypeVariableUnspecToOtherUnspec.java: no unexpected facts
 FAIL: MultiBoundTypeVariableUnspecToSelf.java: no unexpected facts
 FAIL: MultiBoundTypeVariableUnspecToSelfUnionNull.java: no unexpected facts
 FAIL: MultiBoundTypeVariableUnspecToSelfUnspec.java: no unexpected facts
-FAIL: MultiplePathsToTypeVariable.java:71 jspecify_nullness_mismatch
+FAIL: MultiplePathsToTypeVariable.java:71:jspecify_nullness_mismatch
 FAIL: MultiplePathsToTypeVariable.java: no unexpected facts
 FAIL: NoPathToTypeVariableMinusNull.java: no unexpected facts
 PASS: NonConstantPrimitives.java: no unexpected facts
-PASS: NonNullProjection.java:24 jspecify_nullness_mismatch
+PASS: NonNullProjection.java:24:jspecify_nullness_mismatch
 PASS: NonNullProjection.java: no unexpected facts
-PASS: NonNullSimple.java:22 jspecify_nullness_mismatch
+PASS: NonNullSimple.java:22:jspecify_nullness_mismatch
 PASS: NonNullSimple.java: no unexpected facts
 FAIL: NotNullMarkedAnnotatedInnerOfNonParameterized.java: no unexpected facts
 FAIL: NotNullMarkedAnnotatedInnerOfParameterized.java: no unexpected facts
@@ -234,341 +234,341 @@ FAIL: NotNullMarkedConcatResult.java: no unexpected facts
 FAIL: NotNullMarkedContainmentExtends.java: no unexpected facts
 FAIL: NotNullMarkedContainmentSuper.java: no unexpected facts
 FAIL: NotNullMarkedContainmentSuperVsExtends.java: no unexpected facts
-FAIL: NotNullMarkedIfCondition.java:44 jspecify_nullness_mismatch
+FAIL: NotNullMarkedIfCondition.java:44:jspecify_nullness_mismatch
 FAIL: NotNullMarkedIfCondition.java: no unexpected facts
 PASS: NotNullMarkedInferenceChoosesNullableTypeVariable.java: no unexpected facts
-FAIL: NotNullMarkedLocalVariable.java:44 jspecify_nullness_mismatch
+FAIL: NotNullMarkedLocalVariable.java:44:jspecify_nullness_mismatch
 FAIL: NotNullMarkedLocalVariable.java: no unexpected facts
 FAIL: NotNullMarkedOverrides.java: no unexpected facts
-FAIL: NotNullMarkedTypeVariableBound.java:68 jspecify_nullness_mismatch
+FAIL: NotNullMarkedTypeVariableBound.java:68:jspecify_nullness_mismatch
 FAIL: NotNullMarkedTypeVariableBound.java: no unexpected facts
-FAIL: NotNullMarkedUnboxing.java:42 jspecify_nullness_mismatch
-FAIL: NotNullMarkedUnboxing.java:56 jspecify_nullness_mismatch
+FAIL: NotNullMarkedUnboxing.java:42:jspecify_nullness_mismatch
+FAIL: NotNullMarkedUnboxing.java:56:jspecify_nullness_mismatch
 FAIL: NotNullMarkedUnboxing.java: no unexpected facts
-FAIL: NotNullMarkedUseOfTypeVariable.java:48 jspecify_nullness_mismatch
-FAIL: NotNullMarkedUseOfTypeVariable.java:63 jspecify_nullness_mismatch
-FAIL: NotNullMarkedUseOfTypeVariable.java:78 jspecify_nullness_mismatch
-FAIL: NotNullMarkedUseOfTypeVariable.java:83 jspecify_nullness_mismatch
+FAIL: NotNullMarkedUseOfTypeVariable.java:48:jspecify_nullness_mismatch
+FAIL: NotNullMarkedUseOfTypeVariable.java:63:jspecify_nullness_mismatch
+FAIL: NotNullMarkedUseOfTypeVariable.java:78:jspecify_nullness_mismatch
+FAIL: NotNullMarkedUseOfTypeVariable.java:83:jspecify_nullness_mismatch
 FAIL: NotNullMarkedUseOfTypeVariable.java: no unexpected facts
-FAIL: NotNullMarkedUseOfTypeVariableAsTypeArgument.java:51 jspecify_nullness_mismatch
-FAIL: NotNullMarkedUseOfTypeVariableAsTypeArgument.java:66 jspecify_nullness_mismatch
-FAIL: NotNullMarkedUseOfTypeVariableAsTypeArgument.java:81 jspecify_nullness_mismatch
-FAIL: NotNullMarkedUseOfTypeVariableAsTypeArgument.java:86 jspecify_nullness_mismatch
+FAIL: NotNullMarkedUseOfTypeVariableAsTypeArgument.java:51:jspecify_nullness_mismatch
+FAIL: NotNullMarkedUseOfTypeVariableAsTypeArgument.java:66:jspecify_nullness_mismatch
+FAIL: NotNullMarkedUseOfTypeVariableAsTypeArgument.java:81:jspecify_nullness_mismatch
+FAIL: NotNullMarkedUseOfTypeVariableAsTypeArgument.java:86:jspecify_nullness_mismatch
 FAIL: NotNullMarkedUseOfTypeVariableAsTypeArgument.java: no unexpected facts
 FAIL: NotNullMarkedUseOfWildcardAsTypeArgument.java: no unexpected facts
-FAIL: NullCheck.java:28 jspecify_nullness_mismatch
-FAIL: NullCheck.java:37 jspecify_nullness_mismatch
-FAIL: NullCheck.java:44 jspecify_nullness_mismatch
-FAIL: NullCheck.java:53 jspecify_nullness_mismatch
+FAIL: NullCheck.java:28:jspecify_nullness_mismatch
+FAIL: NullCheck.java:37:jspecify_nullness_mismatch
+FAIL: NullCheck.java:44:jspecify_nullness_mismatch
+FAIL: NullCheck.java:53:jspecify_nullness_mismatch
 FAIL: NullCheck.java: no unexpected facts
-FAIL: NullCheckTypeVariable.java:27 jspecify_nullness_mismatch
-FAIL: NullCheckTypeVariable.java:36 jspecify_nullness_mismatch
-FAIL: NullCheckTypeVariable.java:43 jspecify_nullness_mismatch
-FAIL: NullCheckTypeVariable.java:52 jspecify_nullness_mismatch
+FAIL: NullCheckTypeVariable.java:27:jspecify_nullness_mismatch
+FAIL: NullCheckTypeVariable.java:36:jspecify_nullness_mismatch
+FAIL: NullCheckTypeVariable.java:43:jspecify_nullness_mismatch
+FAIL: NullCheckTypeVariable.java:52:jspecify_nullness_mismatch
 FAIL: NullCheckTypeVariable.java: no unexpected facts
-FAIL: NullCheckTypeVariableUnionNullBound.java:27 jspecify_nullness_mismatch
-FAIL: NullCheckTypeVariableUnionNullBound.java:36 jspecify_nullness_mismatch
-FAIL: NullCheckTypeVariableUnionNullBound.java:45 jspecify_nullness_mismatch
-FAIL: NullCheckTypeVariableUnionNullBound.java:52 jspecify_nullness_mismatch
-FAIL: NullCheckTypeVariableUnionNullBound.java:61 jspecify_nullness_mismatch
-FAIL: NullCheckTypeVariableUnionNullBound.java:70 jspecify_nullness_mismatch
+FAIL: NullCheckTypeVariableUnionNullBound.java:27:jspecify_nullness_mismatch
+FAIL: NullCheckTypeVariableUnionNullBound.java:36:jspecify_nullness_mismatch
+FAIL: NullCheckTypeVariableUnionNullBound.java:45:jspecify_nullness_mismatch
+FAIL: NullCheckTypeVariableUnionNullBound.java:52:jspecify_nullness_mismatch
+FAIL: NullCheckTypeVariableUnionNullBound.java:61:jspecify_nullness_mismatch
+FAIL: NullCheckTypeVariableUnionNullBound.java:70:jspecify_nullness_mismatch
 FAIL: NullCheckTypeVariableUnionNullBound.java: no unexpected facts
-FAIL: NullCheckTypeVariableUnspecBound.java:27 jspecify_nullness_mismatch
-FAIL: NullCheckTypeVariableUnspecBound.java:36 jspecify_nullness_mismatch
-FAIL: NullCheckTypeVariableUnspecBound.java:45 jspecify_nullness_mismatch
-FAIL: NullCheckTypeVariableUnspecBound.java:52 jspecify_nullness_mismatch
-FAIL: NullCheckTypeVariableUnspecBound.java:61 jspecify_nullness_mismatch
-FAIL: NullCheckTypeVariableUnspecBound.java:70 jspecify_nullness_mismatch
+FAIL: NullCheckTypeVariableUnspecBound.java:27:jspecify_nullness_mismatch
+FAIL: NullCheckTypeVariableUnspecBound.java:36:jspecify_nullness_mismatch
+FAIL: NullCheckTypeVariableUnspecBound.java:45:jspecify_nullness_mismatch
+FAIL: NullCheckTypeVariableUnspecBound.java:52:jspecify_nullness_mismatch
+FAIL: NullCheckTypeVariableUnspecBound.java:61:jspecify_nullness_mismatch
+FAIL: NullCheckTypeVariableUnspecBound.java:70:jspecify_nullness_mismatch
 FAIL: NullCheckTypeVariableUnspecBound.java: no unexpected facts
-FAIL: NullLiteralToClass.java:24 jspecify_nullness_mismatch
+FAIL: NullLiteralToClass.java:24:jspecify_nullness_mismatch
 FAIL: NullLiteralToClass.java: no unexpected facts
-FAIL: NullLiteralToTypeVariable.java:45 jspecify_nullness_mismatch
-FAIL: NullLiteralToTypeVariable.java:50 jspecify_nullness_mismatch
-FAIL: NullLiteralToTypeVariable.java:55 jspecify_nullness_mismatch
-FAIL: NullLiteralToTypeVariable.java:60 jspecify_nullness_mismatch
-FAIL: NullLiteralToTypeVariable.java:65 jspecify_nullness_mismatch
-FAIL: NullLiteralToTypeVariable.java:70 jspecify_nullness_mismatch
-FAIL: NullLiteralToTypeVariable.java:75 jspecify_nullness_mismatch
-FAIL: NullLiteralToTypeVariable.java:80 jspecify_nullness_mismatch
-FAIL: NullLiteralToTypeVariable.java:85 jspecify_nullness_mismatch
-FAIL: NullLiteralToTypeVariable.java:90 jspecify_nullness_mismatch
-FAIL: NullLiteralToTypeVariable.java:95 jspecify_nullness_mismatch
-FAIL: NullLiteralToTypeVariable.java:100 jspecify_nullness_mismatch
-FAIL: NullLiteralToTypeVariable.java:105 jspecify_nullness_mismatch
-FAIL: NullLiteralToTypeVariable.java:110 jspecify_nullness_mismatch
-FAIL: NullLiteralToTypeVariable.java:115 jspecify_nullness_mismatch
-FAIL: NullLiteralToTypeVariable.java:120 jspecify_nullness_mismatch
+FAIL: NullLiteralToTypeVariable.java:45:jspecify_nullness_mismatch
+FAIL: NullLiteralToTypeVariable.java:50:jspecify_nullness_mismatch
+FAIL: NullLiteralToTypeVariable.java:55:jspecify_nullness_mismatch
+FAIL: NullLiteralToTypeVariable.java:60:jspecify_nullness_mismatch
+FAIL: NullLiteralToTypeVariable.java:65:jspecify_nullness_mismatch
+FAIL: NullLiteralToTypeVariable.java:70:jspecify_nullness_mismatch
+FAIL: NullLiteralToTypeVariable.java:75:jspecify_nullness_mismatch
+FAIL: NullLiteralToTypeVariable.java:80:jspecify_nullness_mismatch
+FAIL: NullLiteralToTypeVariable.java:85:jspecify_nullness_mismatch
+FAIL: NullLiteralToTypeVariable.java:90:jspecify_nullness_mismatch
+FAIL: NullLiteralToTypeVariable.java:95:jspecify_nullness_mismatch
+FAIL: NullLiteralToTypeVariable.java:100:jspecify_nullness_mismatch
+FAIL: NullLiteralToTypeVariable.java:105:jspecify_nullness_mismatch
+FAIL: NullLiteralToTypeVariable.java:110:jspecify_nullness_mismatch
+FAIL: NullLiteralToTypeVariable.java:115:jspecify_nullness_mismatch
+FAIL: NullLiteralToTypeVariable.java:120:jspecify_nullness_mismatch
 FAIL: NullLiteralToTypeVariable.java: no unexpected facts
 FAIL: NullLiteralToTypeVariableUnionNull.java: no unexpected facts
 FAIL: NullLiteralToTypeVariableUnspec.java: no unexpected facts
 FAIL: NullMarkedDirectUseOfNotNullMarkedBoundedTypeVariable.java: no unexpected facts
 FAIL: NullUnmarkedUndoesNullMarked.java: no unexpected facts
 FAIL: NullUnmarkedUndoesNullMarkedForWildcards.java: no unexpected facts
-PASS: NullnessDoesNotAffectOverloadSelection.java:23 jspecify_nullness_mismatch
+PASS: NullnessDoesNotAffectOverloadSelection.java:23:jspecify_nullness_mismatch
 PASS: NullnessDoesNotAffectOverloadSelection.java: no unexpected facts
-PASS: ObjectAsSuperOfTypeVariable.java:35 jspecify_nullness_mismatch
+PASS: ObjectAsSuperOfTypeVariable.java:35:jspecify_nullness_mismatch
 PASS: ObjectAsSuperOfTypeVariable.java: no unexpected facts
-PASS: OutOfBoundsTypeVariable.java:23 jspecify_nullness_mismatch
+PASS: OutOfBoundsTypeVariable.java:23:jspecify_nullness_mismatch
 PASS: OutOfBoundsTypeVariable.java: no unexpected facts
-FAIL: OverrideParameters.java:48 jspecify_nullness_mismatch
-FAIL: OverrideParameters.java:68 jspecify_nullness_mismatch
+FAIL: OverrideParameters.java:48:jspecify_nullness_mismatch
+FAIL: OverrideParameters.java:68:jspecify_nullness_mismatch
 FAIL: OverrideParameters.java: no unexpected facts
 PASS: OverrideParametersThatAreTypeVariables.java: no unexpected facts
-FAIL: OverrideReturns.java:57 jspecify_nullness_mismatch
+FAIL: OverrideReturns.java:57:jspecify_nullness_mismatch
 FAIL: OverrideReturns.java: no unexpected facts
 PASS: ParameterizedWithTypeVariableArgumentToSelf.java: no unexpected facts
 FAIL: PrimitiveAnnotations.java: no unexpected facts
 FAIL: PrimitiveAnnotationsUnspec.java: no unexpected facts
-FAIL: SameTypeObject.java:33 jspecify_nullness_mismatch
-FAIL: SameTypeObject.java:53 jspecify_nullness_mismatch
+FAIL: SameTypeObject.java:33:jspecify_nullness_mismatch
+FAIL: SameTypeObject.java:53:jspecify_nullness_mismatch
 FAIL: SameTypeObject.java: no unexpected facts
-FAIL: SameTypeTypeVariable.java:33 jspecify_nullness_mismatch
-FAIL: SameTypeTypeVariable.java:53 jspecify_nullness_mismatch
+FAIL: SameTypeTypeVariable.java:33:jspecify_nullness_mismatch
+FAIL: SameTypeTypeVariable.java:53:jspecify_nullness_mismatch
 FAIL: SameTypeTypeVariable.java: no unexpected facts
-PASS: SuperNullableForNonNullableTypeParameter.java:29 jspecify_nullness_mismatch
+PASS: SuperNullableForNonNullableTypeParameter.java:29:jspecify_nullness_mismatch
 PASS: SuperNullableForNonNullableTypeParameter.java: no unexpected facts
-FAIL: SuperObject.java:33 jspecify_nullness_mismatch
+FAIL: SuperObject.java:33:jspecify_nullness_mismatch
 FAIL: SuperObject.java: no unexpected facts
 FAIL: SuperObjectUnionNull.java: no unexpected facts
 FAIL: SuperObjectUnspec.java: no unexpected facts
-FAIL: SuperSameType.java:39 jspecify_nullness_mismatch
-FAIL: SuperSameType.java:53 jspecify_nullness_mismatch
+FAIL: SuperSameType.java:39:jspecify_nullness_mismatch
+FAIL: SuperSameType.java:53:jspecify_nullness_mismatch
 FAIL: SuperSameType.java: no unexpected facts
-FAIL: SuperTypeVariable.java:30 jspecify_nullness_mismatch
-FAIL: SuperTypeVariable.java:59 jspecify_nullness_mismatch
-FAIL: SuperTypeVariable.java:88 jspecify_nullness_mismatch
-FAIL: SuperTypeVariable.java:117 jspecify_nullness_mismatch
+FAIL: SuperTypeVariable.java:30:jspecify_nullness_mismatch
+FAIL: SuperTypeVariable.java:59:jspecify_nullness_mismatch
+FAIL: SuperTypeVariable.java:88:jspecify_nullness_mismatch
+FAIL: SuperTypeVariable.java:117:jspecify_nullness_mismatch
 FAIL: SuperTypeVariable.java: no unexpected facts
 FAIL: SuperTypeVariableUnionNull.java: no unexpected facts
 FAIL: SuperTypeVariableUnspec.java: no unexpected facts
-FAIL: SuperVsObject.java:26 jspecify_nullness_mismatch
+FAIL: SuperVsObject.java:26:jspecify_nullness_mismatch
 FAIL: SuperVsObject.java: no unexpected facts
-FAIL: SuperVsSuperNullable.java:31 jspecify_nullness_mismatch
+FAIL: SuperVsSuperNullable.java:31:jspecify_nullness_mismatch
 FAIL: SuperVsSuperNullable.java: no unexpected facts
-FAIL: Ternary.java:33 jspecify_nullness_mismatch
-FAIL: Ternary.java:43 jspecify_nullness_mismatch
-FAIL: Ternary.java:48 jspecify_nullness_mismatch
-FAIL: Ternary.java:57 jspecify_nullness_mismatch
-FAIL: Ternary.java:61 jspecify_nullness_mismatch
+FAIL: Ternary.java:33:jspecify_nullness_mismatch
+FAIL: Ternary.java:43:jspecify_nullness_mismatch
+FAIL: Ternary.java:48:jspecify_nullness_mismatch
+FAIL: Ternary.java:57:jspecify_nullness_mismatch
+FAIL: Ternary.java:61:jspecify_nullness_mismatch
 FAIL: Ternary.java: no unexpected facts
-FAIL: TypeArgumentOfTypeVariableBound.java:37 jspecify_nullness_mismatch
-FAIL: TypeArgumentOfTypeVariableBound.java:57 jspecify_nullness_mismatch
+FAIL: TypeArgumentOfTypeVariableBound.java:37:jspecify_nullness_mismatch
+FAIL: TypeArgumentOfTypeVariableBound.java:57:jspecify_nullness_mismatch
 FAIL: TypeArgumentOfTypeVariableBound.java: no unexpected facts
-FAIL: TypeArgumentOfWildcardBound.java:37 jspecify_nullness_mismatch
-FAIL: TypeArgumentOfWildcardBound.java:58 jspecify_nullness_mismatch
+FAIL: TypeArgumentOfWildcardBound.java:37:jspecify_nullness_mismatch
+FAIL: TypeArgumentOfWildcardBound.java:58:jspecify_nullness_mismatch
 FAIL: TypeArgumentOfWildcardBound.java: no unexpected facts
-PASS: TypeVariableMinusNullVsTypeVariable.java:30 jspecify_nullness_mismatch
-FAIL: TypeVariableMinusNullVsTypeVariable.java:32 jspecify_nullness_mismatch
-PASS: TypeVariableMinusNullVsTypeVariable.java:52 jspecify_nullness_mismatch
+PASS: TypeVariableMinusNullVsTypeVariable.java:30:jspecify_nullness_mismatch
+FAIL: TypeVariableMinusNullVsTypeVariable.java:32:jspecify_nullness_mismatch
+PASS: TypeVariableMinusNullVsTypeVariable.java:52:jspecify_nullness_mismatch
 PASS: TypeVariableMinusNullVsTypeVariable.java: no unexpected facts
-FAIL: TypeVariableToObject.java:58 jspecify_nullness_mismatch
-FAIL: TypeVariableToObject.java:76 jspecify_nullness_mismatch
-FAIL: TypeVariableToObject.java:96 jspecify_nullness_mismatch
-FAIL: TypeVariableToObject.java:101 jspecify_nullness_mismatch
-FAIL: TypeVariableToObject.java:106 jspecify_nullness_mismatch
-FAIL: TypeVariableToObject.java:111 jspecify_nullness_mismatch
-FAIL: TypeVariableToObject.java:116 jspecify_nullness_mismatch
+FAIL: TypeVariableToObject.java:58:jspecify_nullness_mismatch
+FAIL: TypeVariableToObject.java:76:jspecify_nullness_mismatch
+FAIL: TypeVariableToObject.java:96:jspecify_nullness_mismatch
+FAIL: TypeVariableToObject.java:101:jspecify_nullness_mismatch
+FAIL: TypeVariableToObject.java:106:jspecify_nullness_mismatch
+FAIL: TypeVariableToObject.java:111:jspecify_nullness_mismatch
+FAIL: TypeVariableToObject.java:116:jspecify_nullness_mismatch
 FAIL: TypeVariableToObject.java: no unexpected facts
 FAIL: TypeVariableToObjectUnionNull.java: no unexpected facts
 FAIL: TypeVariableToObjectUnspec.java: no unexpected facts
-FAIL: TypeVariableToParent.java:54 jspecify_nullness_mismatch
-FAIL: TypeVariableToParent.java:68 jspecify_nullness_mismatch
-FAIL: TypeVariableToParent.java:82 jspecify_nullness_mismatch
-FAIL: TypeVariableToParent.java:96 jspecify_nullness_mismatch
+FAIL: TypeVariableToParent.java:54:jspecify_nullness_mismatch
+FAIL: TypeVariableToParent.java:68:jspecify_nullness_mismatch
+FAIL: TypeVariableToParent.java:82:jspecify_nullness_mismatch
+FAIL: TypeVariableToParent.java:96:jspecify_nullness_mismatch
 FAIL: TypeVariableToParent.java: no unexpected facts
 FAIL: TypeVariableToParentUnionNull.java: no unexpected facts
 FAIL: TypeVariableToParentUnspec.java: no unexpected facts
 FAIL: TypeVariableToSelf.java: no unexpected facts
 FAIL: TypeVariableToSelfUnionNull.java: no unexpected facts
 FAIL: TypeVariableToSelfUnspec.java: no unexpected facts
-FAIL: TypeVariableUnionNullToObject.java:45 jspecify_nullness_mismatch
-FAIL: TypeVariableUnionNullToObject.java:50 jspecify_nullness_mismatch
-FAIL: TypeVariableUnionNullToObject.java:55 jspecify_nullness_mismatch
-FAIL: TypeVariableUnionNullToObject.java:60 jspecify_nullness_mismatch
-FAIL: TypeVariableUnionNullToObject.java:65 jspecify_nullness_mismatch
-FAIL: TypeVariableUnionNullToObject.java:70 jspecify_nullness_mismatch
-FAIL: TypeVariableUnionNullToObject.java:75 jspecify_nullness_mismatch
-FAIL: TypeVariableUnionNullToObject.java:80 jspecify_nullness_mismatch
-FAIL: TypeVariableUnionNullToObject.java:85 jspecify_nullness_mismatch
-FAIL: TypeVariableUnionNullToObject.java:90 jspecify_nullness_mismatch
-FAIL: TypeVariableUnionNullToObject.java:95 jspecify_nullness_mismatch
-FAIL: TypeVariableUnionNullToObject.java:100 jspecify_nullness_mismatch
-FAIL: TypeVariableUnionNullToObject.java:105 jspecify_nullness_mismatch
-FAIL: TypeVariableUnionNullToObject.java:110 jspecify_nullness_mismatch
-FAIL: TypeVariableUnionNullToObject.java:115 jspecify_nullness_mismatch
-FAIL: TypeVariableUnionNullToObject.java:120 jspecify_nullness_mismatch
+FAIL: TypeVariableUnionNullToObject.java:45:jspecify_nullness_mismatch
+FAIL: TypeVariableUnionNullToObject.java:50:jspecify_nullness_mismatch
+FAIL: TypeVariableUnionNullToObject.java:55:jspecify_nullness_mismatch
+FAIL: TypeVariableUnionNullToObject.java:60:jspecify_nullness_mismatch
+FAIL: TypeVariableUnionNullToObject.java:65:jspecify_nullness_mismatch
+FAIL: TypeVariableUnionNullToObject.java:70:jspecify_nullness_mismatch
+FAIL: TypeVariableUnionNullToObject.java:75:jspecify_nullness_mismatch
+FAIL: TypeVariableUnionNullToObject.java:80:jspecify_nullness_mismatch
+FAIL: TypeVariableUnionNullToObject.java:85:jspecify_nullness_mismatch
+FAIL: TypeVariableUnionNullToObject.java:90:jspecify_nullness_mismatch
+FAIL: TypeVariableUnionNullToObject.java:95:jspecify_nullness_mismatch
+FAIL: TypeVariableUnionNullToObject.java:100:jspecify_nullness_mismatch
+FAIL: TypeVariableUnionNullToObject.java:105:jspecify_nullness_mismatch
+FAIL: TypeVariableUnionNullToObject.java:110:jspecify_nullness_mismatch
+FAIL: TypeVariableUnionNullToObject.java:115:jspecify_nullness_mismatch
+FAIL: TypeVariableUnionNullToObject.java:120:jspecify_nullness_mismatch
 FAIL: TypeVariableUnionNullToObject.java: no unexpected facts
 FAIL: TypeVariableUnionNullToObjectUnionNull.java: no unexpected facts
 FAIL: TypeVariableUnionNullToObjectUnspec.java: no unexpected facts
-FAIL: TypeVariableUnionNullToParent.java:45 jspecify_nullness_mismatch
-FAIL: TypeVariableUnionNullToParent.java:50 jspecify_nullness_mismatch
-FAIL: TypeVariableUnionNullToParent.java:55 jspecify_nullness_mismatch
-FAIL: TypeVariableUnionNullToParent.java:60 jspecify_nullness_mismatch
-FAIL: TypeVariableUnionNullToParent.java:65 jspecify_nullness_mismatch
-FAIL: TypeVariableUnionNullToParent.java:70 jspecify_nullness_mismatch
-FAIL: TypeVariableUnionNullToParent.java:75 jspecify_nullness_mismatch
-FAIL: TypeVariableUnionNullToParent.java:80 jspecify_nullness_mismatch
-FAIL: TypeVariableUnionNullToParent.java:85 jspecify_nullness_mismatch
-FAIL: TypeVariableUnionNullToParent.java:90 jspecify_nullness_mismatch
-FAIL: TypeVariableUnionNullToParent.java:95 jspecify_nullness_mismatch
-FAIL: TypeVariableUnionNullToParent.java:100 jspecify_nullness_mismatch
+FAIL: TypeVariableUnionNullToParent.java:45:jspecify_nullness_mismatch
+FAIL: TypeVariableUnionNullToParent.java:50:jspecify_nullness_mismatch
+FAIL: TypeVariableUnionNullToParent.java:55:jspecify_nullness_mismatch
+FAIL: TypeVariableUnionNullToParent.java:60:jspecify_nullness_mismatch
+FAIL: TypeVariableUnionNullToParent.java:65:jspecify_nullness_mismatch
+FAIL: TypeVariableUnionNullToParent.java:70:jspecify_nullness_mismatch
+FAIL: TypeVariableUnionNullToParent.java:75:jspecify_nullness_mismatch
+FAIL: TypeVariableUnionNullToParent.java:80:jspecify_nullness_mismatch
+FAIL: TypeVariableUnionNullToParent.java:85:jspecify_nullness_mismatch
+FAIL: TypeVariableUnionNullToParent.java:90:jspecify_nullness_mismatch
+FAIL: TypeVariableUnionNullToParent.java:95:jspecify_nullness_mismatch
+FAIL: TypeVariableUnionNullToParent.java:100:jspecify_nullness_mismatch
 FAIL: TypeVariableUnionNullToParent.java: no unexpected facts
 FAIL: TypeVariableUnionNullToParentUnionNull.java: no unexpected facts
 FAIL: TypeVariableUnionNullToParentUnspec.java: no unexpected facts
-FAIL: TypeVariableUnionNullToSelf.java:45 jspecify_nullness_mismatch
-FAIL: TypeVariableUnionNullToSelf.java:50 jspecify_nullness_mismatch
-FAIL: TypeVariableUnionNullToSelf.java:55 jspecify_nullness_mismatch
-FAIL: TypeVariableUnionNullToSelf.java:60 jspecify_nullness_mismatch
-FAIL: TypeVariableUnionNullToSelf.java:65 jspecify_nullness_mismatch
-FAIL: TypeVariableUnionNullToSelf.java:70 jspecify_nullness_mismatch
-FAIL: TypeVariableUnionNullToSelf.java:75 jspecify_nullness_mismatch
-FAIL: TypeVariableUnionNullToSelf.java:80 jspecify_nullness_mismatch
-FAIL: TypeVariableUnionNullToSelf.java:85 jspecify_nullness_mismatch
-FAIL: TypeVariableUnionNullToSelf.java:90 jspecify_nullness_mismatch
-FAIL: TypeVariableUnionNullToSelf.java:95 jspecify_nullness_mismatch
-FAIL: TypeVariableUnionNullToSelf.java:100 jspecify_nullness_mismatch
-FAIL: TypeVariableUnionNullToSelf.java:105 jspecify_nullness_mismatch
-FAIL: TypeVariableUnionNullToSelf.java:110 jspecify_nullness_mismatch
-FAIL: TypeVariableUnionNullToSelf.java:115 jspecify_nullness_mismatch
-FAIL: TypeVariableUnionNullToSelf.java:120 jspecify_nullness_mismatch
+FAIL: TypeVariableUnionNullToSelf.java:45:jspecify_nullness_mismatch
+FAIL: TypeVariableUnionNullToSelf.java:50:jspecify_nullness_mismatch
+FAIL: TypeVariableUnionNullToSelf.java:55:jspecify_nullness_mismatch
+FAIL: TypeVariableUnionNullToSelf.java:60:jspecify_nullness_mismatch
+FAIL: TypeVariableUnionNullToSelf.java:65:jspecify_nullness_mismatch
+FAIL: TypeVariableUnionNullToSelf.java:70:jspecify_nullness_mismatch
+FAIL: TypeVariableUnionNullToSelf.java:75:jspecify_nullness_mismatch
+FAIL: TypeVariableUnionNullToSelf.java:80:jspecify_nullness_mismatch
+FAIL: TypeVariableUnionNullToSelf.java:85:jspecify_nullness_mismatch
+FAIL: TypeVariableUnionNullToSelf.java:90:jspecify_nullness_mismatch
+FAIL: TypeVariableUnionNullToSelf.java:95:jspecify_nullness_mismatch
+FAIL: TypeVariableUnionNullToSelf.java:100:jspecify_nullness_mismatch
+FAIL: TypeVariableUnionNullToSelf.java:105:jspecify_nullness_mismatch
+FAIL: TypeVariableUnionNullToSelf.java:110:jspecify_nullness_mismatch
+FAIL: TypeVariableUnionNullToSelf.java:115:jspecify_nullness_mismatch
+FAIL: TypeVariableUnionNullToSelf.java:120:jspecify_nullness_mismatch
 FAIL: TypeVariableUnionNullToSelf.java: no unexpected facts
 FAIL: TypeVariableUnionNullToSelfUnionNull.java: no unexpected facts
 FAIL: TypeVariableUnionNullToSelfUnspec.java: no unexpected facts
-FAIL: TypeVariableUnspecToObject.java:60 jspecify_nullness_mismatch
-FAIL: TypeVariableUnspecToObject.java:80 jspecify_nullness_mismatch
-FAIL: TypeVariableUnspecToObject.java:100 jspecify_nullness_mismatch
-FAIL: TypeVariableUnspecToObject.java:105 jspecify_nullness_mismatch
-FAIL: TypeVariableUnspecToObject.java:110 jspecify_nullness_mismatch
-FAIL: TypeVariableUnspecToObject.java:115 jspecify_nullness_mismatch
-FAIL: TypeVariableUnspecToObject.java:120 jspecify_nullness_mismatch
+FAIL: TypeVariableUnspecToObject.java:60:jspecify_nullness_mismatch
+FAIL: TypeVariableUnspecToObject.java:80:jspecify_nullness_mismatch
+FAIL: TypeVariableUnspecToObject.java:100:jspecify_nullness_mismatch
+FAIL: TypeVariableUnspecToObject.java:105:jspecify_nullness_mismatch
+FAIL: TypeVariableUnspecToObject.java:110:jspecify_nullness_mismatch
+FAIL: TypeVariableUnspecToObject.java:115:jspecify_nullness_mismatch
+FAIL: TypeVariableUnspecToObject.java:120:jspecify_nullness_mismatch
 FAIL: TypeVariableUnspecToObject.java: no unexpected facts
 FAIL: TypeVariableUnspecToObjectUnionNull.java: no unexpected facts
 FAIL: TypeVariableUnspecToObjectUnspec.java: no unexpected facts
-FAIL: TypeVariableUnspecToParent.java:55 jspecify_nullness_mismatch
-FAIL: TypeVariableUnspecToParent.java:70 jspecify_nullness_mismatch
-FAIL: TypeVariableUnspecToParent.java:85 jspecify_nullness_mismatch
-FAIL: TypeVariableUnspecToParent.java:100 jspecify_nullness_mismatch
+FAIL: TypeVariableUnspecToParent.java:55:jspecify_nullness_mismatch
+FAIL: TypeVariableUnspecToParent.java:70:jspecify_nullness_mismatch
+FAIL: TypeVariableUnspecToParent.java:85:jspecify_nullness_mismatch
+FAIL: TypeVariableUnspecToParent.java:100:jspecify_nullness_mismatch
 FAIL: TypeVariableUnspecToParent.java: no unexpected facts
 FAIL: TypeVariableUnspecToParentUnionNull.java: no unexpected facts
 FAIL: TypeVariableUnspecToParentUnspec.java: no unexpected facts
 FAIL: TypeVariableUnspecToSelf.java: no unexpected facts
 FAIL: TypeVariableUnspecToSelfUnionNull.java: no unexpected facts
 FAIL: TypeVariableUnspecToSelfUnspec.java: no unexpected facts
-FAIL: Unboxing.java:33 jspecify_nullness_mismatch
-FAIL: Unboxing.java:47 jspecify_nullness_mismatch
+FAIL: Unboxing.java:33:jspecify_nullness_mismatch
+FAIL: Unboxing.java:47:jspecify_nullness_mismatch
 FAIL: Unboxing.java: no unexpected facts
-FAIL: UninitializedField.java:23 jspecify_nullness_mismatch
-FAIL: UninitializedField.java:31 jspecify_nullness_mismatch
+FAIL: UninitializedField.java:23:jspecify_nullness_mismatch
+FAIL: UninitializedField.java:31:jspecify_nullness_mismatch
 FAIL: UninitializedField.java: no unexpected facts
-FAIL: UnionTypeArgumentWithUseSite.java:73 jspecify_nullness_mismatch
-FAIL: UnionTypeArgumentWithUseSite.java:87 jspecify_nullness_mismatch
-FAIL: UnionTypeArgumentWithUseSite.java:93 jspecify_nullness_mismatch
-FAIL: UnionTypeArgumentWithUseSite.java:97 jspecify_nullness_mismatch
-FAIL: UnionTypeArgumentWithUseSite.java:101 jspecify_nullness_mismatch
+FAIL: UnionTypeArgumentWithUseSite.java:73:jspecify_nullness_mismatch
+FAIL: UnionTypeArgumentWithUseSite.java:87:jspecify_nullness_mismatch
+FAIL: UnionTypeArgumentWithUseSite.java:93:jspecify_nullness_mismatch
+FAIL: UnionTypeArgumentWithUseSite.java:97:jspecify_nullness_mismatch
+FAIL: UnionTypeArgumentWithUseSite.java:101:jspecify_nullness_mismatch
 FAIL: UnionTypeArgumentWithUseSite.java: no unexpected facts
 FAIL: UnrecognizedLocationsMisc.java: no unexpected facts
-PASS: UnspecifiedClassTypeArgumentForNonNullableParameter.java:28 jspecify_nullness_mismatch
+PASS: UnspecifiedClassTypeArgumentForNonNullableParameter.java:28:jspecify_nullness_mismatch
 FAIL: UnspecifiedClassTypeArgumentForNonNullableParameter.java: no unexpected facts
 FAIL: UnspecifiedTypeArgumentForNonNullableParameter.java: no unexpected facts
 FAIL: UnspecifiedTypeArgumentForNonNullableParameterRepeatedSubstitution.java: no unexpected facts
 FAIL: UnspecifiedTypeArgumentForNonNullableParameterUseUnspec.java: no unexpected facts
-PASS: UnspecifiedTypeVariableTypeArgumentForNonNullableParameter.java:28 jspecify_nullness_mismatch
+PASS: UnspecifiedTypeVariableTypeArgumentForNonNullableParameter.java:28:jspecify_nullness_mismatch
 FAIL: UnspecifiedTypeVariableTypeArgumentForNonNullableParameter.java: no unexpected facts
-FAIL: UseOfTypeVariableAsTypeArgument.java:46 jspecify_nullness_mismatch
-FAIL: UseOfTypeVariableAsTypeArgument.java:60 jspecify_nullness_mismatch
-FAIL: UseOfTypeVariableAsTypeArgument.java:74 jspecify_nullness_mismatch
-FAIL: UseOfTypeVariableAsTypeArgument.java:79 jspecify_nullness_mismatch
+FAIL: UseOfTypeVariableAsTypeArgument.java:46:jspecify_nullness_mismatch
+FAIL: UseOfTypeVariableAsTypeArgument.java:60:jspecify_nullness_mismatch
+FAIL: UseOfTypeVariableAsTypeArgument.java:74:jspecify_nullness_mismatch
+FAIL: UseOfTypeVariableAsTypeArgument.java:79:jspecify_nullness_mismatch
 FAIL: UseOfTypeVariableAsTypeArgument.java: no unexpected facts
-FAIL: UseOfTypeVariableUnionNullAsTypeArgument.java:37 jspecify_nullness_mismatch
-FAIL: UseOfTypeVariableUnionNullAsTypeArgument.java:42 jspecify_nullness_mismatch
-FAIL: UseOfTypeVariableUnionNullAsTypeArgument.java:47 jspecify_nullness_mismatch
-FAIL: UseOfTypeVariableUnionNullAsTypeArgument.java:52 jspecify_nullness_mismatch
-FAIL: UseOfTypeVariableUnionNullAsTypeArgument.java:57 jspecify_nullness_mismatch
-FAIL: UseOfTypeVariableUnionNullAsTypeArgument.java:62 jspecify_nullness_mismatch
-FAIL: UseOfTypeVariableUnionNullAsTypeArgument.java:67 jspecify_nullness_mismatch
-FAIL: UseOfTypeVariableUnionNullAsTypeArgument.java:72 jspecify_nullness_mismatch
-FAIL: UseOfTypeVariableUnionNullAsTypeArgument.java:77 jspecify_nullness_mismatch
-FAIL: UseOfTypeVariableUnionNullAsTypeArgument.java:82 jspecify_nullness_mismatch
+FAIL: UseOfTypeVariableUnionNullAsTypeArgument.java:37:jspecify_nullness_mismatch
+FAIL: UseOfTypeVariableUnionNullAsTypeArgument.java:42:jspecify_nullness_mismatch
+FAIL: UseOfTypeVariableUnionNullAsTypeArgument.java:47:jspecify_nullness_mismatch
+FAIL: UseOfTypeVariableUnionNullAsTypeArgument.java:52:jspecify_nullness_mismatch
+FAIL: UseOfTypeVariableUnionNullAsTypeArgument.java:57:jspecify_nullness_mismatch
+FAIL: UseOfTypeVariableUnionNullAsTypeArgument.java:62:jspecify_nullness_mismatch
+FAIL: UseOfTypeVariableUnionNullAsTypeArgument.java:67:jspecify_nullness_mismatch
+FAIL: UseOfTypeVariableUnionNullAsTypeArgument.java:72:jspecify_nullness_mismatch
+FAIL: UseOfTypeVariableUnionNullAsTypeArgument.java:77:jspecify_nullness_mismatch
+FAIL: UseOfTypeVariableUnionNullAsTypeArgument.java:82:jspecify_nullness_mismatch
 FAIL: UseOfTypeVariableUnionNullAsTypeArgument.java: no unexpected facts
-FAIL: UseOfTypeVariableUnspecAsTypeArgument.java:47 jspecify_nullness_mismatch
-FAIL: UseOfTypeVariableUnspecAsTypeArgument.java:62 jspecify_nullness_mismatch
-FAIL: UseOfTypeVariableUnspecAsTypeArgument.java:77 jspecify_nullness_mismatch
-FAIL: UseOfTypeVariableUnspecAsTypeArgument.java:82 jspecify_nullness_mismatch
+FAIL: UseOfTypeVariableUnspecAsTypeArgument.java:47:jspecify_nullness_mismatch
+FAIL: UseOfTypeVariableUnspecAsTypeArgument.java:62:jspecify_nullness_mismatch
+FAIL: UseOfTypeVariableUnspecAsTypeArgument.java:77:jspecify_nullness_mismatch
+FAIL: UseOfTypeVariableUnspecAsTypeArgument.java:82:jspecify_nullness_mismatch
 FAIL: UseOfTypeVariableUnspecAsTypeArgument.java: no unexpected facts
-FAIL: WildcardBoundWithAnnotations.java:44 jspecify_nullness_mismatch
+FAIL: WildcardBoundWithAnnotations.java:44:jspecify_nullness_mismatch
 FAIL: WildcardBoundWithAnnotations.java: no unexpected facts
-PASS: WildcardCapturesToBoundOfTypeParameterNotToTypeVariableItself.java:26 jspecify_nullness_mismatch
+PASS: WildcardCapturesToBoundOfTypeParameterNotToTypeVariableItself.java:26:jspecify_nullness_mismatch
 PASS: WildcardCapturesToBoundOfTypeParameterNotToTypeVariableItself.java: no unexpected facts
-FAIL: annotatedBoundsOfWildcard/annotatedboundsofwildcard/AnnotatedBoundsOfWildcard.java:76 jspecify_nullness_mismatch
-FAIL: annotatedBoundsOfWildcard/annotatedboundsofwildcard/AnnotatedBoundsOfWildcard.java:78 jspecify_nullness_mismatch
-FAIL: annotatedBoundsOfWildcard/annotatedboundsofwildcard/AnnotatedBoundsOfWildcard.java:89 jspecify_nullness_mismatch
-FAIL: annotatedBoundsOfWildcard/annotatedboundsofwildcard/AnnotatedBoundsOfWildcard.java:91 jspecify_nullness_mismatch
-FAIL: annotatedBoundsOfWildcard/annotatedboundsofwildcard/AnnotatedBoundsOfWildcard.java:93 jspecify_nullness_mismatch
-FAIL: annotatedBoundsOfWildcard/annotatedboundsofwildcard/AnnotatedBoundsOfWildcard.java:95 jspecify_nullness_mismatch
-FAIL: annotatedBoundsOfWildcard/annotatedboundsofwildcard/AnnotatedBoundsOfWildcard.java:106 jspecify_nullness_mismatch
-FAIL: annotatedBoundsOfWildcard/annotatedboundsofwildcard/AnnotatedBoundsOfWildcard.java:108 jspecify_nullness_mismatch
-FAIL: annotatedBoundsOfWildcard/annotatedboundsofwildcard/AnnotatedBoundsOfWildcard.java:110 jspecify_nullness_mismatch
+FAIL: annotatedBoundsOfWildcard/annotatedboundsofwildcard/AnnotatedBoundsOfWildcard.java:76:jspecify_nullness_mismatch
+FAIL: annotatedBoundsOfWildcard/annotatedboundsofwildcard/AnnotatedBoundsOfWildcard.java:78:jspecify_nullness_mismatch
+FAIL: annotatedBoundsOfWildcard/annotatedboundsofwildcard/AnnotatedBoundsOfWildcard.java:89:jspecify_nullness_mismatch
+FAIL: annotatedBoundsOfWildcard/annotatedboundsofwildcard/AnnotatedBoundsOfWildcard.java:91:jspecify_nullness_mismatch
+FAIL: annotatedBoundsOfWildcard/annotatedboundsofwildcard/AnnotatedBoundsOfWildcard.java:93:jspecify_nullness_mismatch
+FAIL: annotatedBoundsOfWildcard/annotatedboundsofwildcard/AnnotatedBoundsOfWildcard.java:95:jspecify_nullness_mismatch
+FAIL: annotatedBoundsOfWildcard/annotatedboundsofwildcard/AnnotatedBoundsOfWildcard.java:106:jspecify_nullness_mismatch
+FAIL: annotatedBoundsOfWildcard/annotatedboundsofwildcard/AnnotatedBoundsOfWildcard.java:108:jspecify_nullness_mismatch
+FAIL: annotatedBoundsOfWildcard/annotatedboundsofwildcard/AnnotatedBoundsOfWildcard.java:110:jspecify_nullness_mismatch
 FAIL: annotatedBoundsOfWildcard/annotatedboundsofwildcard/AnnotatedBoundsOfWildcard.java: no unexpected facts
-FAIL: defaults/defaults/Defaults.java:25 jspecify_nullness_mismatch
-FAIL: defaults/defaults/Defaults.java:30 jspecify_nullness_mismatch
-FAIL: defaults/defaults/Defaults.java:48 jspecify_nullness_mismatch
-FAIL: defaults/defaults/Defaults.java:71 jspecify_nullness_mismatch
-FAIL: defaults/defaults/Defaults.java:75 jspecify_nullness_mismatch
-FAIL: defaults/defaults/Defaults.java:81 jspecify_nullness_mismatch
-FAIL: defaults/defaults/Defaults.java:83 jspecify_nullness_mismatch
-FAIL: defaults/defaults/Defaults.java:92 jspecify_nullness_mismatch
+FAIL: defaults/defaults/Defaults.java:25:jspecify_nullness_mismatch
+FAIL: defaults/defaults/Defaults.java:30:jspecify_nullness_mismatch
+FAIL: defaults/defaults/Defaults.java:48:jspecify_nullness_mismatch
+FAIL: defaults/defaults/Defaults.java:71:jspecify_nullness_mismatch
+FAIL: defaults/defaults/Defaults.java:75:jspecify_nullness_mismatch
+FAIL: defaults/defaults/Defaults.java:81:jspecify_nullness_mismatch
+FAIL: defaults/defaults/Defaults.java:83:jspecify_nullness_mismatch
+FAIL: defaults/defaults/Defaults.java:92:jspecify_nullness_mismatch
 FAIL: defaults/defaults/Defaults.java: no unexpected facts
 PASS: fullyQualified/fullyqualified/sub/Annotation.java: no unexpected facts
 PASS: fullyQualified/fullyqualified/sub/Caller.java: no unexpected facts
 PASS: fullyQualified/fullyqualified/sub/Clazz.java: no unexpected facts
 PASS: fullyQualified/fullyqualified/sub/Enumeration.java: no unexpected facts
 PASS: fullyQualified/fullyqualified/sub/Interface.java: no unexpected facts
-FAIL: ignoreAnnotations/ignoreannotations/IgnoreAnnotations.java:32 jspecify_nullness_mismatch
-FAIL: ignoreAnnotations/ignoreannotations/IgnoreAnnotations.java:63 jspecify_nullness_mismatch
-FAIL: ignoreAnnotations/ignoreannotations/IgnoreAnnotations.java:65 jspecify_nullness_mismatch
-FAIL: ignoreAnnotations/ignoreannotations/IgnoreAnnotations.java:68 jspecify_nullness_mismatch
-FAIL: ignoreAnnotations/ignoreannotations/IgnoreAnnotations.java:71 jspecify_nullness_mismatch
-FAIL: ignoreAnnotations/ignoreannotations/IgnoreAnnotations.java:75 jspecify_nullness_mismatch
+FAIL: ignoreAnnotations/ignoreannotations/IgnoreAnnotations.java:32:jspecify_nullness_mismatch
+FAIL: ignoreAnnotations/ignoreannotations/IgnoreAnnotations.java:63:jspecify_nullness_mismatch
+FAIL: ignoreAnnotations/ignoreannotations/IgnoreAnnotations.java:65:jspecify_nullness_mismatch
+FAIL: ignoreAnnotations/ignoreannotations/IgnoreAnnotations.java:68:jspecify_nullness_mismatch
+FAIL: ignoreAnnotations/ignoreannotations/IgnoreAnnotations.java:71:jspecify_nullness_mismatch
+FAIL: ignoreAnnotations/ignoreannotations/IgnoreAnnotations.java:75:jspecify_nullness_mismatch
 FAIL: ignoreAnnotations/ignoreannotations/IgnoreAnnotations.java: no unexpected facts
 PASS: implementWithNullableTypeArgument/implementwithnullabletypeargument/MyFunction.java: no unexpected facts
 PASS: implementWithNullableTypeArgument/implementwithnullabletypeargument/SuperFunction.java: no unexpected facts
 PASS: implementWithNullableTypeArgument/implementwithnullabletypeargument/User.java: no unexpected facts
 PASS: memberSelectNonExpression/memberselectnonexpression/MemberSelectNonExpressions.java: no unexpected facts
 PASS: nonPlatformTypeParameter/nonplatformtypeparameter/NonPlatformTypeParameter.java: no unexpected facts
-PASS: nullnessUnspecifiedTypeParameter/nullnessunspecifiedtypeparameter/NullnessUnspecifiedTypeParameter.java:35 jspecify_nullness_mismatch
-PASS: nullnessUnspecifiedTypeParameter/nullnessunspecifiedtypeparameter/NullnessUnspecifiedTypeParameter.java:43 jspecify_nullness_mismatch
-PASS: nullnessUnspecifiedTypeParameter/nullnessunspecifiedtypeparameter/NullnessUnspecifiedTypeParameter.java:47 jspecify_nullness_mismatch
-PASS: nullnessUnspecifiedTypeParameter/nullnessunspecifiedtypeparameter/NullnessUnspecifiedTypeParameter.java:51 jspecify_nullness_mismatch
-PASS: nullnessUnspecifiedTypeParameter/nullnessunspecifiedtypeparameter/NullnessUnspecifiedTypeParameter.java:53 jspecify_nullness_mismatch
-PASS: nullnessUnspecifiedTypeParameter/nullnessunspecifiedtypeparameter/NullnessUnspecifiedTypeParameter.java:57 jspecify_nullness_mismatch
-PASS: nullnessUnspecifiedTypeParameter/nullnessunspecifiedtypeparameter/NullnessUnspecifiedTypeParameter.java:59 jspecify_nullness_mismatch
+PASS: nullnessUnspecifiedTypeParameter/nullnessunspecifiedtypeparameter/NullnessUnspecifiedTypeParameter.java:35:jspecify_nullness_mismatch
+PASS: nullnessUnspecifiedTypeParameter/nullnessunspecifiedtypeparameter/NullnessUnspecifiedTypeParameter.java:43:jspecify_nullness_mismatch
+PASS: nullnessUnspecifiedTypeParameter/nullnessunspecifiedtypeparameter/NullnessUnspecifiedTypeParameter.java:47:jspecify_nullness_mismatch
+PASS: nullnessUnspecifiedTypeParameter/nullnessunspecifiedtypeparameter/NullnessUnspecifiedTypeParameter.java:51:jspecify_nullness_mismatch
+PASS: nullnessUnspecifiedTypeParameter/nullnessunspecifiedtypeparameter/NullnessUnspecifiedTypeParameter.java:53:jspecify_nullness_mismatch
+PASS: nullnessUnspecifiedTypeParameter/nullnessunspecifiedtypeparameter/NullnessUnspecifiedTypeParameter.java:57:jspecify_nullness_mismatch
+PASS: nullnessUnspecifiedTypeParameter/nullnessunspecifiedtypeparameter/NullnessUnspecifiedTypeParameter.java:59:jspecify_nullness_mismatch
 PASS: nullnessUnspecifiedTypeParameter/nullnessunspecifiedtypeparameter/NullnessUnspecifiedTypeParameter.java: no unexpected facts
-PASS: packageDefault/packagedefault/Bar.java:23 test:cannot-convert:Object? to Object!
+PASS: packageDefault/packagedefault/Bar.java:23:test:cannot-convert:Object? to Object!
 PASS: packageDefault/packagedefault/Bar.java: no unexpected facts
 PASS: packageDefault/packagedefault/package-info.java: no unexpected facts
-PASS: selfType/selftype/SelfType.java:36 test:cannot-convert:AK? to SelfType!<AK!>
-PASS: selfType/selftype/SelfType.java:45 test:cannot-convert:CK? to C!<CK!>
-PASS: selfType/selftype/SelfType.java:61 test:cannot-convert:null? to AK!
-PASS: selfType/selftype/SelfType.java:64 test:cannot-convert:null? to AK!
-PASS: selfType/selftype/SelfType.java:68 test:cannot-convert:null? to B!
-PASS: selfType/selftype/SelfType.java:72 test:cannot-convert:null? to CK!
-PASS: selfType/selftype/SelfType.java:75 test:cannot-convert:null? to CK!
+PASS: selfType/selftype/SelfType.java:36:test:cannot-convert:AK? to SelfType!<AK!>
+PASS: selfType/selftype/SelfType.java:45:test:cannot-convert:CK? to C!<CK!>
+PASS: selfType/selftype/SelfType.java:61:test:cannot-convert:null? to AK!
+PASS: selfType/selftype/SelfType.java:64:test:cannot-convert:null? to AK!
+PASS: selfType/selftype/SelfType.java:68:test:cannot-convert:null? to B!
+PASS: selfType/selftype/SelfType.java:72:test:cannot-convert:null? to CK!
+PASS: selfType/selftype/SelfType.java:75:test:cannot-convert:null? to CK!
 FAIL: selfType/selftype/SelfType.java: no unexpected facts
-FAIL: simple/simple/Simple.java:32 jspecify_nullness_mismatch
-FAIL: simple/simple/Simple.java:46 jspecify_nullness_mismatch
-FAIL: simple/simple/Simple.java:48 jspecify_nullness_mismatch
-FAIL: simple/simple/Simple.java:53 jspecify_nullness_mismatch
+FAIL: simple/simple/Simple.java:32:jspecify_nullness_mismatch
+FAIL: simple/simple/Simple.java:46:jspecify_nullness_mismatch
+FAIL: simple/simple/Simple.java:48:jspecify_nullness_mismatch
+FAIL: simple/simple/Simple.java:53:jspecify_nullness_mismatch
 FAIL: simple/simple/Simple.java: no unexpected facts
-FAIL: typeArgumentsFromParameterBounds/typeargumentsfromparameterbounds/TypeArgumentsFromParameterBounds.java:51 jspecify_nullness_mismatch
-FAIL: typeArgumentsFromParameterBounds/typeargumentsfromparameterbounds/TypeArgumentsFromParameterBounds.java:53 jspecify_nullness_mismatch
-FAIL: typeArgumentsFromParameterBounds/typeargumentsfromparameterbounds/TypeArgumentsFromParameterBounds.java:55 jspecify_nullness_mismatch
+FAIL: typeArgumentsFromParameterBounds/typeargumentsfromparameterbounds/TypeArgumentsFromParameterBounds.java:51:jspecify_nullness_mismatch
+FAIL: typeArgumentsFromParameterBounds/typeargumentsfromparameterbounds/TypeArgumentsFromParameterBounds.java:53:jspecify_nullness_mismatch
+FAIL: typeArgumentsFromParameterBounds/typeargumentsfromparameterbounds/TypeArgumentsFromParameterBounds.java:55:jspecify_nullness_mismatch
 FAIL: typeArgumentsFromParameterBounds/typeargumentsfromparameterbounds/TypeArgumentsFromParameterBounds.java: no unexpected facts
-FAIL: typeParameterBounds/typeparameterbounds/TypeParameterBounds.java:42 jspecify_nullness_mismatch
-FAIL: typeParameterBounds/typeparameterbounds/TypeParameterBounds.java:45 jspecify_nullness_mismatch
-FAIL: typeParameterBounds/typeparameterbounds/TypeParameterBounds.java:51 jspecify_nullness_mismatch
-FAIL: typeParameterBounds/typeparameterbounds/TypeParameterBounds.java:55 jspecify_nullness_mismatch
-FAIL: typeParameterBounds/typeparameterbounds/TypeParameterBounds.java:57 jspecify_nullness_mismatch
-FAIL: typeParameterBounds/typeparameterbounds/TypeParameterBounds.java:61 jspecify_nullness_mismatch
-FAIL: typeParameterBounds/typeparameterbounds/TypeParameterBounds.java:63 jspecify_nullness_mismatch
+FAIL: typeParameterBounds/typeparameterbounds/TypeParameterBounds.java:42:jspecify_nullness_mismatch
+FAIL: typeParameterBounds/typeparameterbounds/TypeParameterBounds.java:45:jspecify_nullness_mismatch
+FAIL: typeParameterBounds/typeparameterbounds/TypeParameterBounds.java:51:jspecify_nullness_mismatch
+FAIL: typeParameterBounds/typeparameterbounds/TypeParameterBounds.java:55:jspecify_nullness_mismatch
+FAIL: typeParameterBounds/typeparameterbounds/TypeParameterBounds.java:57:jspecify_nullness_mismatch
+FAIL: typeParameterBounds/typeparameterbounds/TypeParameterBounds.java:61:jspecify_nullness_mismatch
+FAIL: typeParameterBounds/typeparameterbounds/TypeParameterBounds.java:63:jspecify_nullness_mismatch
 FAIL: typeParameterBounds/typeparameterbounds/TypeParameterBounds.java: no unexpected facts
 FAIL: wildcardsWithDefault/wildcardswithdefault/WildcardsWithDefault.java: no unexpected facts


### PR DESCRIPTION
Part of the fix for https://github.com/jspecify/jspecify-reference-checker/issues/141.